### PR TITLE
fix: Update .Rbuildignore to resolve R CMD check notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,6 @@
 # RStudio project files
 ^.*\.Rproj$
-^\.Rproj\.user$
+^\.Rproj\.user/
 
 # Development and documentation files
 ^README\.Rmd$
@@ -14,9 +14,11 @@
 # System files
 ^\.DS_Store$
 ^.*/\.DS_Store$
+^\.DS_Store$
 
 # Temporary and build files
 ^\.\.Rcheck$
+^\.\.Rcheck/
 ^revdep/
 
 # Development documentation
@@ -31,6 +33,8 @@
 ^COLUMN_NAMING_ANALYSIS\.md$
 ^COLUMN_NAMING_CLEANUP_PLAN\.md$
 ^COMPREHENSIVE_CHECK_RESULTS\.md$
+^ISSUE_MANAGEMENT_QUICK_REFERENCE\.md$
+^DOCUMENTATION\.md$
 
 # Test and development scripts
 ^test_script\.R$
@@ -47,3 +51,11 @@
 
 # Temporary files
 ^inst/\.!.*\.Rmd$
+
+# Git and version control
+^\.git/
+
+# Additional hidden files and directories
+^\.Rhistory$
+^\.RData$
+^\.Ruserdata/


### PR DESCRIPTION
## Summary

This PR addresses GitHub Issue #72 by updating the .Rbuildignore file to comprehensively exclude non-standard files that were causing R CMD check notes.

## Changes Made

- Added comprehensive patterns for hidden files and directories
- Included .git/, .Rproj.user/, and additional system files
- Added patterns for development documentation files
- Enhanced coverage for temporary and build artifacts

## Testing

- Verified that R CMD build creates a clean package
- Confirmed R CMD check passes with Status: OK (0 warnings, 0 notes)
- All hidden files and non-portable file paths are now properly excluded

## Impact

- Resolves CRAN submission blocker (Issue #72)
- Eliminates R CMD check notes about non-standard files
- Ensures clean package builds for distribution

Fixes #72