### PR TITLE
chore: Update .gitignore and rebuild vignettes with improved formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Temporary Items
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
+vignettes/*.R
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth

--- a/doc/plotting.R
+++ b/doc/plotting.R
@@ -115,7 +115,7 @@ plot_users_masked_section_by_metric(
 ## ----custom-filtering---------------------------------------------------------
 # Filter for specific sections
 section_data <- transcripts_summary_df %>%
-  filter(section == 1)  # Use the actual section number from our sample data
+  filter(section == 1) # Use the actual section number from our sample data
 
 # Plot filtered data
 plot_users_by_metric(section_data, metric = "wpm")
@@ -148,7 +148,7 @@ engagement_categories <- transcripts_summary_df %>%
   mutate(
     engagement_type = case_when(
       n == 0 ~ "No participation",
-      n <= 2 ~ "Low participation", 
+      n <= 2 ~ "Low participation",
       n <= 5 ~ "Moderate participation",
       TRUE ~ "High participation"
     )

--- a/doc/plotting.Rmd
+++ b/doc/plotting.Rmd
@@ -187,7 +187,7 @@ Filter data for specific analysis:
 ```{r custom-filtering}
 # Filter for specific sections
 section_data <- transcripts_summary_df %>%
-  filter(section == 1)  # Use the actual section number from our sample data
+  filter(section == 1) # Use the actual section number from our sample data
 
 # Plot filtered data
 plot_users_by_metric(section_data, metric = "wpm")
@@ -237,7 +237,7 @@ engagement_categories <- transcripts_summary_df %>%
   mutate(
     engagement_type = case_when(
       n == 0 ~ "No participation",
-      n <= 2 ~ "Low participation", 
+      n <= 2 ~ "Low participation",
       n <= 5 ~ "Moderate participation",
       TRUE ~ "High participation"
     )

--- a/doc/plotting.html
+++ b/doc/plotting.html
@@ -513,7 +513,7 @@ time</li>
 <p>Filter data for specific analysis:</p>
 <div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Filter for specific sections</span></span>
 <span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>section_data <span class="ot">&lt;-</span> transcripts_summary_df <span class="sc">%&gt;%</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">filter</span>(section <span class="sc">==</span> <span class="dv">1</span>)  <span class="co"># Use the actual section number from our sample data</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">filter</span>(section <span class="sc">==</span> <span class="dv">1</span>) <span class="co"># Use the actual section number from our sample data</span></span>
 <span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="co"># Plot filtered data</span></span>
 <span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="fu">plot_users_by_metric</span>(section_data, <span class="at">metric =</span> <span class="st">&quot;wpm&quot;</span>)</span>
@@ -569,7 +569,7 @@ time</li>
 <span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">mutate</span>(</span>
 <span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">engagement_type =</span> <span class="fu">case_when</span>(</span>
 <span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>      n <span class="sc">==</span> <span class="dv">0</span> <span class="sc">~</span> <span class="st">&quot;No participation&quot;</span>,</span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>      n <span class="sc">&lt;=</span> <span class="dv">2</span> <span class="sc">~</span> <span class="st">&quot;Low participation&quot;</span>, </span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>      n <span class="sc">&lt;=</span> <span class="dv">2</span> <span class="sc">~</span> <span class="st">&quot;Low participation&quot;</span>,</span>
 <span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>      n <span class="sc">&lt;=</span> <span class="dv">5</span> <span class="sc">~</span> <span class="st">&quot;Moderate participation&quot;</span>,</span>
 <span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>      <span class="cn">TRUE</span> <span class="sc">~</span> <span class="st">&quot;High participation&quot;</span></span>
 <span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>    )</span>

--- a/doc/roster-cleaning.R
+++ b/doc/roster-cleaning.R
@@ -126,7 +126,7 @@ if ("preferred_name" %in% colnames(roster_df)) {
 # In the lookup file, set:
 # transcript_name: "Guest Speaker"
 # preferred_name: "Guest"
-# formal_name: "Guest Speaker" 
+# formal_name: "Guest Speaker"
 # student_id: "GUEST001"
 # section: "LTF.201.1"
 

--- a/doc/roster-cleaning.Rmd
+++ b/doc/roster-cleaning.Rmd
@@ -230,7 +230,7 @@ For special cases like guest speakers:
 # In the lookup file, set:
 # transcript_name: "Guest Speaker"
 # preferred_name: "Guest"
-# formal_name: "Guest Speaker" 
+# formal_name: "Guest Speaker"
 # student_id: "GUEST001"
 # section: "LTF.201.1"
 ```

--- a/doc/roster-cleaning.html
+++ b/doc/roster-cleaning.html
@@ -623,7 +623,7 @@ analysis</li>
 <span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="co"># In the lookup file, set:</span></span>
 <span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="co"># transcript_name: &quot;Guest Speaker&quot;</span></span>
 <span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="co"># preferred_name: &quot;Guest&quot;</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="co"># formal_name: &quot;Guest Speaker&quot; </span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="co"># formal_name: &quot;Guest Speaker&quot;</span></span>
 <span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="co"># student_id: &quot;GUEST001&quot;</span></span>
 <span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="co"># section: &quot;LTF.201.1&quot;</span></span></code></pre></div>
 </div>

--- a/doc/session-mapping.R
+++ b/doc/session-mapping.R
@@ -67,7 +67,7 @@ session_mapping <- create_session_mapping(
   output_file = config$session_mapping$session_mapping_file,
   auto_assign_patterns = list(
     "CS 101" = "CS.*101",
-    "MATH 250" = "MATH.*250", 
+    "MATH 250" = "MATH.*250",
     "LTF 201" = "LTF.*201"
   ),
   interactive = FALSE # Set to TRUE for interactive mode
@@ -139,7 +139,7 @@ head(transcripts_metrics_df)
 # Example of custom patterns
 custom_patterns <- list(
   "CS 101 Section 1" = "CS.*101.*Section.*1|CS.*101.*Monday",
-  "CS 101 Section 2" = "CS.*101.*Section.*2|CS.*101.*Wednesday", 
+  "CS 101 Section 2" = "CS.*101.*Section.*2|CS.*101.*Wednesday",
   "MATH 250" = "MATH.*250|Mathematics.*250",
   "LTF 201" = "LTF.*201|Language.*201"
 )

--- a/doc/session-mapping.Rmd
+++ b/doc/session-mapping.Rmd
@@ -118,7 +118,7 @@ session_mapping <- create_session_mapping(
   output_file = config$session_mapping$session_mapping_file,
   auto_assign_patterns = list(
     "CS 101" = "CS.*101",
-    "MATH 250" = "MATH.*250", 
+    "MATH 250" = "MATH.*250",
     "LTF 201" = "LTF.*201"
   ),
   interactive = FALSE # Set to TRUE for interactive mode
@@ -223,7 +223,7 @@ Create custom assignment patterns:
 # Example of custom patterns
 custom_patterns <- list(
   "CS 101 Section 1" = "CS.*101.*Section.*1|CS.*101.*Monday",
-  "CS 101 Section 2" = "CS.*101.*Section.*2|CS.*101.*Wednesday", 
+  "CS 101 Section 2" = "CS.*101.*Section.*2|CS.*101.*Wednesday",
   "MATH 250" = "MATH.*250|Mathematics.*250",
   "LTF 201" = "LTF.*201|Language.*201"
 )

--- a/doc/session-mapping.html
+++ b/doc/session-mapping.html
@@ -509,7 +509,7 @@ overlapping Zoom recordings.</p>
 <span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">output_file =</span> config<span class="sc">$</span>session_mapping<span class="sc">$</span>session_mapping_file,</span>
 <span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">auto_assign_patterns =</span> <span class="fu">list</span>(</span>
 <span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;CS 101&quot;</span> <span class="ot">=</span> <span class="st">&quot;CS.*101&quot;</span>,</span>
-<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;MATH 250&quot;</span> <span class="ot">=</span> <span class="st">&quot;MATH.*250&quot;</span>, </span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;MATH 250&quot;</span> <span class="ot">=</span> <span class="st">&quot;MATH.*250&quot;</span>,</span>
 <span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;LTF 201&quot;</span> <span class="ot">=</span> <span class="st">&quot;LTF.*201&quot;</span></span>
 <span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  ),</span>
 <span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">interactive =</span> <span class="cn">FALSE</span> <span class="co"># Set to TRUE for interactive mode</span></span>
@@ -667,7 +667,7 @@ overlapping Zoom recordings.</p>
 <div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Example of custom patterns</span></span>
 <span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>custom_patterns <span class="ot">&lt;-</span> <span class="fu">list</span>(</span>
 <span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;CS 101 Section 1&quot;</span> <span class="ot">=</span> <span class="st">&quot;CS.*101.*Section.*1|CS.*101.*Monday&quot;</span>,</span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;CS 101 Section 2&quot;</span> <span class="ot">=</span> <span class="st">&quot;CS.*101.*Section.*2|CS.*101.*Wednesday&quot;</span>, </span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;CS 101 Section 2&quot;</span> <span class="ot">=</span> <span class="st">&quot;CS.*101.*Section.*2|CS.*101.*Wednesday&quot;</span>,</span>
 <span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;MATH 250&quot;</span> <span class="ot">=</span> <span class="st">&quot;MATH.*250|Mathematics.*250&quot;</span>,</span>
 <span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;LTF 201&quot;</span> <span class="ot">=</span> <span class="st">&quot;LTF.*201|Language.*201&quot;</span></span>
 <span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>)</span>

--- a/doc/transcript-processing.R
+++ b/doc/transcript-processing.R
@@ -109,7 +109,7 @@ head(deduplicated_metrics)
 custom_processed <- process_zoom_transcript(
   transcript_file_path = transcript_file,
   consolidate_comments = TRUE,
-  max_pause_sec = 2,  # Longer pause threshold
+  max_pause_sec = 2, # Longer pause threshold
   add_dead_air = TRUE,
   dead_air_name = "silence",
   na_name = "unidentified"

--- a/doc/transcript-processing.Rmd
+++ b/doc/transcript-processing.Rmd
@@ -173,7 +173,7 @@ Fine-tune the processing parameters:
 custom_processed <- process_zoom_transcript(
   transcript_file_path = transcript_file,
   consolidate_comments = TRUE,
-  max_pause_sec = 2,  # Longer pause threshold
+  max_pause_sec = 2, # Longer pause threshold
   add_dead_air = TRUE,
   dead_air_name = "silence",
   na_name = "unidentified"

--- a/doc/transcript-processing.html
+++ b/doc/transcript-processing.html
@@ -595,7 +595,7 @@ transcripts using the <code>zoomstudentengagement</code> package.</p>
 <span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>custom_processed <span class="ot">&lt;-</span> <span class="fu">process_zoom_transcript</span>(</span>
 <span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">transcript_file_path =</span> transcript_file,</span>
 <span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">consolidate_comments =</span> <span class="cn">TRUE</span>,</span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">max_pause_sec =</span> <span class="dv">2</span>,  <span class="co"># Longer pause threshold</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">max_pause_sec =</span> <span class="dv">2</span>, <span class="co"># Longer pause threshold</span></span>
 <span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">add_dead_air =</span> <span class="cn">TRUE</span>,</span>
 <span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">dead_air_name =</span> <span class="st">&quot;silence&quot;</span>,</span>
 <span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">na_name =</span> <span class="st">&quot;unidentified&quot;</span></span>


### PR DESCRIPTION
## Summary
Cleanup changes to improve repository organization and vignette formatting.

## Changes
- **Updated .gitignore**: Added  to ignore generated source files
- **Rebuilt vignettes**: Applied improved formatting and whitespace consistency
- **Cleaned up**: Removed untracked generated files from vignettes directory

## Why These Changes
- The generated  files in vignettes/ should not be tracked (they're build artifacts)
- Vignette rebuilding improved formatting consistency
- These are minor but legitimate improvements from the GitHub Pages setup process

## Testing
- All vignettes still build and render correctly
- GitHub Pages deployment continues to work
- No functional changes to package behavior