### PR TITLE
feat: Add AI assistant guidelines to .cursorrules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -321,4 +321,16 @@ devtools::build()                    # Create distributable package
 - Use consistent naming conventions
 - Write comprehensive documentation
 - Maintain high test coverage
-- Regular code reviews and updates 
+- Regular code reviews and updates
+
+## AI Assistant Guidelines
+
+### Context Requirements
+- Reference current GitHub issues when asking questions
+- Mention CRAN compliance status (0 errors, 0 warnings target)
+- Include test coverage requirement (>90%)
+
+### Educational Focus
+- Prioritize participation equity over surveillance
+- Default to privacy-conscious behavior in suggestions
+- Focus on positive educational outcomes


### PR DESCRIPTION
## Summary

Add minimal AI assistant guidelines to .cursorrules to improve AI collaboration while maintaining focus on CRAN submission priorities.

## Changes

- **Added AI Assistant Guidelines section** (10 lines total)
- **Context Requirements**: Reference GitHub issues, mention CRAN compliance status, include test coverage requirement
- **Educational Focus**: Prioritize participation equity over surveillance, default to privacy-conscious behavior, focus on positive educational outcomes

## Benefits

- ✅ **Minimal footprint**: Only 10 lines added to 334-line file
- ✅ **Focused**: Addresses specific AI assistance needs
- ✅ **Non-disruptive**: No changes to existing workflow
- ✅ **CRAN-aligned**: Supports current CRAN submission priorities

## Testing

- [x] Changes follow existing .cursorrules structure
- [x] No breaking changes to existing configuration
- [x] Maintains project's educational and ethical focus

## Related Issues

This addresses the need for better AI assistant guidance while avoiding overengineering and maintaining focus on CRAN submission.