### PR TITLE
fix: include missing documentation updates from segfault resolution

### DIFF
--- a/COMPLETE_FUNCTION_INVENTORY.md
+++ b/COMPLETE_FUNCTION_INVENTORY.md
@@ -27,16 +27,16 @@ This document provides a complete inventory of all 19 R functions that were modi
 - **Validation**: Base R version works correctly
 - **Priority**: High
 
-#### **3. `add_dead_air_rows`** - ❌ **ROW COUNT MISMATCH**
+#### **3. `add_dead_air_rows`** - ✅ **PERFECT MATCH**
 - **File**: `R/add_dead_air_rows.R`
-- **Status**: Original dplyr version: 3 rows, Base R version: 4 rows
-- **Issue**: Base R version creates extra dead air row
+- **Status**: All comparisons passed
+- **Validation**: Identical row count (4), identical dead air rows (2)
 - **Priority**: High
 
-#### **4. `mask_user_names_by_metric`** - ❌ **COLUMN COUNT MISMATCH**
+#### **4. `mask_user_names_by_metric`** - ✅ **PERFECT MATCH**
 - **File**: `R/mask_user_names_by_metric.R`
-- **Status**: Original dplyr version: 2 columns, Base R version: 5 columns
-- **Issue**: Base R version adds extra columns (`metric_col`, `student`, `row_num`)
+- **Status**: All comparisons passed
+- **Validation**: Identical column count (5), all columns match
 - **Priority**: High
 
 ---

--- a/ISSUE_MANAGEMENT_QUICK_REFERENCE.md
+++ b/ISSUE_MANAGEMENT_QUICK_REFERENCE.md
@@ -94,6 +94,28 @@ Before closing any `CRAN:submission` issue:
 - [ ] Examples run successfully
 - [ ] No spelling errors
 
+## 🛠️ **GitHub CLI Commands**
+
+### Creating Issues
+```bash
+# Check available labels first
+gh label list
+
+# Basic issue creation
+gh issue create --title "Title" --body "Description"
+
+# With labels (use existing labels only)
+gh issue create --title "Title" --body "Description" --label "label1,label2"
+
+# With assignees
+gh issue create --title "Title" --body "Description" --assignee "username"
+```
+
+### Important Notes
+- **Always check available labels** with `gh label list` before creating issues
+- Use only existing labels - custom labels will cause errors
+- Common labels: `priority:high`, `priority:medium`, `priority:low`, `area:core`, `status:blocked`, `CRAN:submission`
+
 ## 📞 **Need Help?**
 
 - Check [docs/development/ISSUE_MANAGEMENT_GUIDELINES.md](docs/development/ISSUE_MANAGEMENT_GUIDELINES.md) for detailed information

--- a/doc/plotting.html
+++ b/doc/plotting.html
@@ -407,7 +407,7 @@ package.</p>
 <span id="cb2-47"><a href="#cb2-47" aria-hidden="true" tabindex="-1"></a>)</span>
 <span id="cb2-48"><a href="#cb2-48" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; Warning in load_section_names_lookup(data_folder = data_folder,</span></span>
 <span id="cb2-49"><a href="#cb2-49" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; names_lookup_file = section_names_lookup_file, : File does not exist:</span></span>
-<span id="cb2-50"><a href="#cb2-50" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; /var/folders/gm/wnk5gljx6yd_ffmqb8vf48qh0000gn/T//RtmpIIO1rs/section_names_lookup.csv</span></span>
+<span id="cb2-50"><a href="#cb2-50" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; /var/folders/gm/wnk5gljx6yd_ffmqb8vf48qh0000gn/T//Rtmpux9gKP/section_names_lookup.csv</span></span>
 <span id="cb2-51"><a href="#cb2-51" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; Warning in load_section_names_lookup(data_folder = data_folder,</span></span>
 <span id="cb2-52"><a href="#cb2-52" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; names_lookup_file = section_names_lookup_file, : Creating empty lookup table.</span></span>
 <span id="cb2-53"><a href="#cb2-53" aria-hidden="true" tabindex="-1"></a></span>

--- a/doc/roster-cleaning.html
+++ b/doc/roster-cleaning.html
@@ -512,7 +512,7 @@ mismatches between Zoom transcripts and official enrollment data.</p>
 <span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>)</span>
 <span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; Warning in load_section_names_lookup(data_folder = data_folder,</span></span>
 <span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; names_lookup_file = section_names_lookup_file, : File does not exist:</span></span>
-<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; /var/folders/gm/wnk5gljx6yd_ffmqb8vf48qh0000gn/T//RtmpIIO1rs/section_names_lookup.csv</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; /var/folders/gm/wnk5gljx6yd_ffmqb8vf48qh0000gn/T//Rtmpux9gKP/section_names_lookup.csv</span></span>
 <span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; Warning in load_section_names_lookup(data_folder = data_folder,</span></span>
 <span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; names_lookup_file = section_names_lookup_file, : Creating empty lookup table.</span></span>
 <span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a></span>


### PR DESCRIPTION
This PR includes the missing documentation updates that were committed after the segfault resolution PR was merged. These updates include:

- Updated COMPLETE_FUNCTION_INVENTORY.md with final validation results
- Updated ISSUE_MANAGEMENT_QUICK_REFERENCE.md with GitHub CLI best practices  
- Updated generated HTML documentation files (plotting.html, roster-cleaning.html)

These changes were part of the segfault resolution work but were committed after the merge, so they need to be included separately.