### PR TITLE
fix: Add pandoc to GitHub Actions for vignette building

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev pandoc
         shell: bash
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes GitHub Actions R-CMD-check failure by installing pandoc for R Markdown vignette building. The workflow was failing with 'Pandoc is required to build R Markdown vignettes but not available' error.