### PR TITLE
chore: privacy-defaults follow-ups (docs, tests)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,6 +23,9 @@
 
 # Development documentation
 ^docs/
+^CONTEXT_SCRIPTS_ENHANCEMENT\.md$
+^ISSUE_20_COVERAGE_TODO\.md$
+^PROJECT\.md\.backup\..*$
 ^AUDIT_LOG\.md$
 ^CONTRIBUTING\.md$
 ^CRAN_CHECKLIST\.md$

--- a/R/ensure_privacy.R
+++ b/R/ensure_privacy.R
@@ -17,6 +17,8 @@
 #'
 #' @return The object with privacy rules applied. For data frames, the same
 #'   structure is preserved with identifying fields masked when appropriate.
+#'
+#' @seealso [set_privacy_defaults()]
 #' @export
 #'
 #' @examples

--- a/R/set_privacy_defaults.R
+++ b/R/set_privacy_defaults.R
@@ -8,6 +8,8 @@
 #' @param privacy_level One of `c("mask", "none")`. Defaults to `"mask"`.
 #'
 #' @return Invisibly returns the chosen privacy level.
+#'
+#' @seealso [ensure_privacy()]
 #' @export
 #'
 #' @examples

--- a/README.Rmd
+++ b/README.Rmd
@@ -127,6 +127,8 @@ set_privacy_defaults("none")  # will emit a warning
 set_privacy_defaults("mask")  # restore safe default
 ```
 
+Masked by default: `preferred_name`, `name`, `first_last`, `name_raw`, `student_id`, `email`.
+
 See the vignette "Ethical & FERPA Guide" for details.
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ set_privacy_defaults("none")  # will emit a warning
 set_privacy_defaults("mask")  # restore safe default
 ```
 
+Masked by default: `preferred_name`, `name`, `first_last`, `name_raw`,
+`student_id`, `email`.
+
 See the vignette “Ethical & FERPA Guide” for details.
 
 ## 🤝 Contributing

--- a/man/ensure_privacy.Rd
+++ b/man/ensure_privacy.Rd
@@ -44,3 +44,6 @@ df <- tibble::tibble(
 )
 ensure_privacy(df)
 }
+\seealso{
+[set_privacy_defaults()]
+}

--- a/man/set_privacy_defaults.Rd
+++ b/man/set_privacy_defaults.Rd
@@ -25,3 +25,6 @@ set_privacy_defaults("mask")
 # Temporarily disable masking (will emit a warning)
 set_privacy_defaults("none")
 }
+\seealso{
+[ensure_privacy()]
+}

--- a/tests/testthat/test-write_engagement_metrics.R
+++ b/tests/testthat/test-write_engagement_metrics.R
@@ -254,6 +254,26 @@ test_that("write_engagement_metrics works with real transcript data", {
   }
 })
 
+test_that("write_engagement_metrics masks identifier columns by default", {
+  metrics_data <- tibble::tibble(
+    name = c("Alice", "Bob"),
+    student_id = c("S1", "S2"),
+    duration = c(10, 20)
+  )
+
+  temp_file <- tempfile(fileext = ".csv")
+  on.exit(unlink(temp_file), add = TRUE)
+
+  result <- write_engagement_metrics(metrics_data, temp_file)
+  # name and student_id should be masked to Student NN pattern
+  expect_true(all(grepl("^Student \\d{2}$", result$name)))
+  expect_true(all(grepl("^Student \\d{2}$", result$student_id)))
+
+  written <- readr::read_csv(temp_file, show_col_types = FALSE)
+  expect_true(all(grepl("^Student \\d{2}$", written$name)))
+  expect_true(all(grepl("^Student \\d{2}$", written$student_id)))
+})
+
 test_that("write_engagement_metrics warns about list columns other than comments", {
   # Create test data with list columns other than comments
   test_data <- tibble::tibble(

--- a/vignettes/ferpa-ethics.Rmd
+++ b/vignettes/ferpa-ethics.Rmd
@@ -20,7 +20,8 @@ getOption("zoomstudentengagement.privacy_level")
 ```
 
 to `"mask"` unless you have set it otherwise. This ensures personally
-identifying fields such as `preferred_name`, `name`, and `student_id` are
+identifying fields such as `preferred_name`, `name`, `first_last`, `name_raw`,
+`student_id`, and `email` are
 masked to generic labels like `Student 01`.
 
 ## Changing behavior (not recommended)


### PR DESCRIPTION
Follow-up to privacy-defaults MVP:

- Roxygen: @seealso cross-links between ensure_privacy\(\) and set_privacy_defaults\(\)
- README: Privacy Defaults section lists masked columns
- Vignette: FERPA guide lists masked columns
- Rd: regenerated for new cross-links
- Tests: write_engagement_metrics masked identifiers (CSV and return)

No API changes; CI remains green. Merge after review.