### PR TITLE
ci: fix Pages deploy by building pkgdown and uploading ./docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,13 +27,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::pkgdown
+            any::devtools
+      - name: Build pkgdown site
+        run: |
+          Rscript -e "devtools::document();"
+          Rscript -e "pkgdown::build_site(lazy = TRUE, override = list(destination = 'docs'))"
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: './doc'
+          # Upload the generated site
+          path: './docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4 


### PR DESCRIPTION
Fixes Pages workflow failures:
- Build pkgdown site
- Upload ./docs artifact (previously ./doc did not exist)
- Uses setup-r and setup-r-dependencies for pkgdown

After merge, re-run Pages workflow from Actions to publish site.