### PR TITLE
fix(issues-sync): URL-encode search query; retry on failure

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -32,4 +32,8 @@ jobs:
         run: |
           chmod +x scripts/create_issues_from_plan.sh
           if [ "${{ github.event.inputs.update }}" = "true" ]; then export UPDATE_IF_EXISTS=1; fi
-          scripts/create_issues_from_plan.sh "${{ github.event.inputs.plan_path }}" "${{ github.event.inputs.milestone }}" "${{ github.event.inputs.tracking_title }}"
+          scripts/create_issues_from_plan.sh "${{ github.event.inputs.plan_path }}" "${{ github.event.inputs.milestone }}" "${{ github.event.inputs.tracking_title }}" || {
+            echo "Sync failed; trying again with sanitized titles (URL-encoded search)";
+            sed -i 's/curl -sS \"\${API}\/search\/issues\?q=.*/curl -sS --get \"\${API}\/search\/issues\" \"\${HEADERS[@]}\" \\\n    --data-urlencode \"q=repo:\${REPO} in:title \$title\"\)/' scripts/create_issues_from_plan.sh;
+            scripts/create_issues_from_plan.sh "${{ github.event.inputs.plan_path }}" "${{ github.event.inputs.milestone }}" "${{ github.event.inputs.tracking_title }}";
+          }

--- a/scripts/create_issues_from_plan.sh
+++ b/scripts/create_issues_from_plan.sh
@@ -116,8 +116,9 @@ for ((i=0; i<${#sections[@]}; i++)); do
     continue
   fi
 
-  # Check for existing issue by exact title
-  existing_json=$(curl -sS "${API}/search/issues?q=repo:${REPO}+in:title+\"$(printf '%s' "$title" | sed 's/"/%22/g')\"" "${HEADERS[@]}")
+  # Check for existing issue by exact title (URL-encode query via --data-urlencode)
+  existing_json=$(curl -sS --get "${API}/search/issues" "${HEADERS[@]}" \
+    --data-urlencode "q=repo:${REPO} in:title ${title}")
   existing_count=$(echo "$existing_json" | sed -nE 's/.*"total_count": ([0-9]+).*/\1/p')
   if [ "${existing_count:-0}" -gt 0 ]; then
     existing_num=$(echo "$existing_json" | sed -nE 's/.*"number": ([0-9]+).*/\1/p' | head -n1)


### PR DESCRIPTION
Fix the issues sync workflow failure by URL-encoding the search API query and adding a retry path in the workflow step. This addresses curl malformed URL errors when titles contain special characters.