### PR TITLE
fix: Use pre-built Docker image for background agents (Issue #253)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,26 @@
+{
+  "name": "zoomstudentengagement-r-package",
+  "user": "ruser",
+  "install": "echo 'Using pre-built image - no installation needed'",
+  "start": "echo 'R package environment ready - everything pre-installed'",
+  "terminals": [
+    {
+      "name": "R Console",
+      "command": "R"
+    },
+    {
+      "name": "Run Tests",
+      "command": "R -e \"devtools::test()\""
+    }
+  ],
+  "ports": [
+    {
+      "name": "R Shiny App",
+      "port": 3838
+    }
+  ],
+  "image": "zoomstudentengagement:agent",
+  "context": ".",
+  "buildArgs": {},
+  "target": null
+}

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ rsconnect/
 # Cursor AI
 .cursor/*
 !.cursor/context.md
+!.cursor/environment.json
 .cursor.json
 example_test_results.rds
 


### PR DESCRIPTION
## Summary

Fixes Issue #253 - Background agent still installing R instead of using pre-built Docker image.

## Problem
After fixing Issue #251, the background agent was still trying to install R and dependencies at runtime instead of using our pre-built Docker image.

## Root Cause
The .cursor/environment.json was configured to build from Dockerfile.agent instead of using the pre-built zoomstudentengagement:agent image.

## Solution

### 1. Updated Environment Configuration
**File**: .cursor/environment.json
- Changed from `dockerfile: "Dockerfile.agent"` to `image: "zoomstudentengagement:agent"`
- Removed install command since everything is pre-installed
- Updated start command to reflect pre-built status

### 2. Updated Git Configuration
**File**: .gitignore
- Added exception for .cursor/environment.json so it can be tracked in git

## Expected Behavior

Background agent should now:
1. ✅ Use pre-built zoomstudentengagement:agent image
2. ✅ No installation needed at runtime
3. ✅ Direct access to R and all packages
4. ✅ Immediate test execution

## Files Changed

### Modified
- .cursor/environment.json - Use pre-built image instead of building from Dockerfile
- .gitignore - Allow tracking of .cursor/environment.json

## Testing

The pre-built image contains:
- ✅ R 4.4.0 with all system dependencies
- ✅ All R packages from DESCRIPTION file
- ✅ zoomstudentengagement package installed
- ✅ Non-root user (ruser) for security

## Performance Impact

- **Before**: Background agent builds Docker image + installs R + installs packages
- **After**: Background agent uses pre-built image with everything ready

This should significantly improve background agent startup time and reliability.

Fixes #253