### PR TITLE
chore(context): route PROJECT.md backups to .cursor/backups; ignore legacy backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ example_test_results.rds
 .cursor_backup/
 Dockerfile.backup
 
+# Legacy project backups created by older scripts
+PROJECT.md.backup.*
+
 # Auto-generated documentation files
 # doc/ directory contains only auto-generated HTML files from vignettes
 # Source files (.Rmd, .R) are now properly located in vignettes/

--- a/scripts/save-context.sh
+++ b/scripts/save-context.sh
@@ -30,10 +30,11 @@ update_project_sections() {
         return 1
     fi
     
-    # Create backup
+    # Create backup under .cursor/backups to avoid repo noise
     echo "💾 Creating backup..."
-    cp PROJECT.md PROJECT.md.backup.$(date '+%Y%m%d_%H%M%S')
-    echo "✅ Backup created"
+    mkdir -p .cursor/backups
+    cp PROJECT.md .cursor/backups/PROJECT.md.backup.$(date '+%Y%m%d_%H%M%S')
+    echo "✅ Backup created (.cursor/backups)"
     
     # Create unique temp files to avoid race conditions
     TIMESTAMP=$(date '+%Y%m%d_%H%M%S')_$$
@@ -213,8 +214,9 @@ update_project_metrics() {
     # Create backup if fixing
     if [ "$action" = "fix" ]; then
         echo "💾 Creating backup..."
-        cp PROJECT.md PROJECT.md.backup.$(date '+%Y%m%d_%H%M%S')
-        echo "✅ Backup created"
+        mkdir -p .cursor/backups
+        cp PROJECT.md .cursor/backups/PROJECT.md.backup.$(date '+%Y%m%d_%H%M%S')
+        echo "✅ Backup created (.cursor/backups)"
     fi
     
     # Create temporary updated file


### PR DESCRIPTION
This removes untracked backup noise:

- save-context: send PROJECT.md backups to .cursor/backups
- .gitignore: ignore legacy PROJECT.md.backup.*

Closes #278.