### PR TITLE
docs(plan): add validation summary and Diagnostic Output Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,26 @@ devtools::check()                    # Full package check
 devtools::build()                    # Create distributable package
 ```
 
+### Diagnostic Output Policy
+
+- Default to quiet output. Provide a `verbose = FALSE` argument for functions that may emit diagnostics.
+- Gate any `print()`, `message()`, or `cat()` calls behind both the verbose flag and the test guard, for example:
+  ```r
+  if (isTRUE(verbose) && Sys.getenv("TESTTHAT") != "true") {
+    message("detailed status...")
+  }
+  ```
+- Guard interactive prompts with `interactive()` and provide non-interactive fallbacks:
+  ```r
+  if (interactive()) {
+    # prompt user
+  } else {
+    # fallback path without prompting
+  }
+  ```
+- Keep examples runnable and quiet by default; avoid stray diagnostics in examples and tests.
+- The pre-PR validator enforces this policy; ensure it reports "All diagnostic output properly conditional" before opening a PR.
+
 ### Managing Issues from Markdown Plans
 
 We maintain a Markdown plan at `ISSUES/docs_overhaul_plan.md` and sync it to GitHub Issues.

--- a/docs/development/AUDIT_LOG.md
+++ b/docs/development/AUDIT_LOG.md
@@ -476,6 +476,43 @@ The package has significant technical debt that needs addressing before CRAN sub
 
 ---
 
+### [2025-08-20] Pre-PR validation summary and remediation plan
+
+**Status**: Tests pass; R CMD check clean (1 NOTE: future timestamps); coverage 87.9%
+
+**Key Findings**
+- Diagnostic output in runtime code not gated behind TESTTHAT/interactive guards
+- Minor shell script hygiene: missing trailing newline at EOF in 3 scripts
+- Coverage below target (>90%) at 87.9%
+- Context helper prints a false-positive "PROJECT.md update required" banner when up to date
+
+**Issues Created**
+- #307 docs(plan): document validation results and remediation plan
+- #308 chore(test-output): gate diagnostic output in runtime code
+- #309 chore(scripts): add trailing newline at EOF in 3 scripts
+- #310 test(coverage): raise coverage to ≥90%
+- #311 chore(context): fix PROJECT.md “update required” false-positive
+
+**Planned Remediation (docs-first PR before code changes)**
+1. Add Diagnostic Output Policy to CONTRIBUTING.md clarifying:
+   - Prefer `verbose = FALSE` defaults; gate `print()`, `message()`, `cat()` with `if (verbose && Sys.getenv("TESTTHAT") != "true")`
+   - Guard interactive prompts with `interactive()` and provide non-interactive fallbacks
+   - Avoid stray diagnostic output in examples/tests; keep examples runnable and quiet by default
+2. Implement gating in `R/create_session_mapping.R`, `R/load_zoom_recorded_sessions_list.R`, `R/make_new_analysis_template.R`, `R/utils_diagnostics.R`
+3. Add trailing newlines to `scripts/create-issues-batch.sh`, `scripts/create-spinoff-issues.sh`, `scripts/pre-commit.sh`
+4. Add targeted tests to lift coverage to ≥90%
+5. Fix save-context PROJECT.md sync false-positive
+
+**Acceptance Criteria**
+- Pre-PR validator reports: "All diagnostic output properly conditional"
+- No EOF newline warnings
+- `covr::package_coverage()` ≥ 90%
+- Context helper emits no update banner when PROJECT.md is in sync
+
+**Next Steps**
+- Merge docs-only PR (Closes #307), then proceed with focused fix branches for #308–#311 and coverage uplift
+
+
 Refer to the [Master Tracking Issue #15](https://github.com/revgizmo/zoomstudentengagement_cursor/issues/15) for the audit checklist and sub-issues. 
 
 ### [2025-07-28] Documentation Organization Audit


### PR DESCRIPTION
Closes #307\n\nThis PR adds:\n- AUDIT_LOG.md entry with pre-PR validation summary and remediation plan (issues #308–#311, #310)\n- CONTRIBUTING.md Diagnostic Output Policy: verbose flag, TESTTHAT guard, interactive() prompts, quiet examples\n\nNo functional changes. Please merge before fix branches for #308–#311 and #310.