### PR TITLE
docs(readme): add CI coverage badge (Fixes #187)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(
 # zoomstudentengagement
 
 <!-- badges: start -->
+[![coverage](https://img.shields.io/github/actions/workflow/status/revgizmo/zoomstudentengagement/coverage.yaml?branch=main&label=coverage)](https://github.com/revgizmo/zoomstudentengagement/actions/workflows/coverage.yaml)
 <!-- badges: end -->
 
 The goal of `zoomstudentengagement` is to allow instructors to gain insights into student engagement, with a particular focus on participation equity, from Zoom transcripts of recorded course sessions.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
 # zoomstudentengagement
 
 <!-- badges: start -->
+
+[![coverage](https://img.shields.io/github/actions/workflow/status/revgizmo/zoomstudentengagement/coverage.yaml?branch=main&label=coverage)](https://github.com/revgizmo/zoomstudentengagement/actions/workflows/coverage.yaml)
 <!-- badges: end -->
 
 The goal of `zoomstudentengagement` is to allow instructors to gain


### PR DESCRIPTION
This adds a README badge for the coverage workflow. It reflects the latest run on main.

- Badge uses shields to display workflow status and is linked to the coverage workflow page
- Keeps secrets footprint low; no external Codecov token required

Rationale: quick visibility into coverage gate status alongside other badges.
