### PR TITLE
chore(rcmd-notes): ignore non-standard top-level files; document timestamp NOTE as environment-related (Fixes #299, Refs #77)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -164,3 +164,5 @@
 ^debug-summary\.md$
 ^docker-removal-log\.md$
 ^LICENSE\.md$
+^ISSUE_308_IMPLEMENTATION_GUIDE\.md$
+^ISSUE_310_IMPLEMENTATION_GUIDE\.md$

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -70,7 +70,7 @@ A comprehensive ethical analysis conducted on 2025-08-04 revealed **CATASTROPHIC
  - **CI Enhancements**: Added benchmark workflow with configurable performance budgets; expanded R-CMD-check matrix across OS/R versions.
  - **Traceability Updates**: Filed follow-up issues for hygiene and enforcement: #206 (deprecation badges/timeline), #207 (curate exports), #208 (schema/provenance docs), #209 (benchmark budgets), #210 (edge/error-path tests), #211 (`.Rbuildignore` top-level dirs).
  - **Test Suite**: **1650 tests passing, 0 failures**
- - **R CMD Check**: **0 errors, 0 warnings, 2 notes** (excellent progress!)
+ - **R CMD Check**: **0 errors, 0 warnings, 1 note** (future timestamp check: "unable to verify current time"; environment-related and acceptable)
  - **Test Coverage**: 90.22% (target achieved)
 
 ### What Needs Work ❌ (Critical Issues for CRAN)

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -354,8 +354,8 @@ A comprehensive premortem analysis conducted on 2025-08-04 revealed fundamental 
 
 ### 🎉 **Major Success Achieved**
 The project has made **outstanding progress** toward CRAN submission:
-- **Test Suite**: **1500 tests passing, 0 failures**
-- **R CMD Check**: **0 errors, 0 warnings, 2 notes** (excellent progress!)
+- **Test Suite**: **1650 tests passing, 0 failures**
+- **R CMD Check**: **0 errors, 0 warnings, 1 note** (future timestamp check: "unable to verify current time"; environment-related and acceptable)
 - **CRAN Compliance**: All major blockers resolved
 - **Package Status**: Technically sound but has critical privacy/ethical risks
 


### PR DESCRIPTION
This PR addresses remaining R CMD check notes:

- Add  entries for  and  to clear the top-level files NOTE.
- Document the remaining NOTE: . Based on prior experience and common guidance, this stems from environment clock verification; it is acceptable and non-actionable for CRAN when reproducible locally.

Validation:
- devtools::check(): 0 errors, 0 warnings, 1 note
- Tests: 1650 passing; Coverage: 90.22%

Follow-ups:
- If CRAN flags timestamp NOTE, we can re-check on rhub/winbuilder to confirm environment behavior.
