### PR TITLE
fix(workflow): Handle empty lookup files gracefully

### DIFF
--- a/scripts/real_world_testing/whole_game_real_world.Rmd
+++ b/scripts/real_world_testing/whole_game_real_world.Rmd
@@ -436,14 +436,23 @@ if (file.exists(lookup_file)) {
     }
   } else {
     cat("⚠️  Lookup file missing participant_type column.\n")
-    cat("Adding participant_type column and instructor configuration (preserving existing entries)...\n")
     
-    # Add participant_type column to existing entries and add instructor
-    existing_lookup$participant_type <- "enrolled_student"  # Default for existing entries
-    instructor_lookup <- create_instructor_entries(instructor_name)
-    updated_lookup <- rbind(existing_lookup, instructor_lookup)
-    safe_update_lookup_file(updated_lookup, lookup_file)
-    cat("✅ Added participant_type column and instructor configuration (preserved existing entries).\n")
+    # Check if the file is empty
+    if (nrow(existing_lookup) == 0) {
+      cat("File is empty. Creating new lookup file with instructor configuration...\n")
+      instructor_lookup <- create_instructor_entries(instructor_name)
+      safe_update_lookup_file(instructor_lookup, lookup_file)
+      cat("✅ Created new lookup file with instructor configuration.\n")
+    } else {
+      cat("Adding participant_type column and instructor configuration (preserving existing entries)...\n")
+      
+      # Add participant_type column to existing entries and add instructor
+      existing_lookup$participant_type <- "enrolled_student"  # Default for existing entries
+      instructor_lookup <- create_instructor_entries(instructor_name)
+      updated_lookup <- rbind(existing_lookup, instructor_lookup)
+      safe_update_lookup_file(updated_lookup, lookup_file)
+      cat("✅ Added participant_type column and instructor configuration (preserved existing entries).\n")
+    }
   }
 } else {
   cat("\n=== Creating Instructor Configuration ===\n")
@@ -798,12 +807,22 @@ if (exists("transcript_data") && exists("roster")) {
           cat("✅ Instructor already configured in lookup file.\n")
         }
       } else {
-        cat("⚠️  Lookup file missing participant_type column. Adding participant_type and instructor configuration (preserving existing entries)...\n")
-        current_lookup$participant_type <- "enrolled_student"  # Default for existing entries
-        instructor_entry <- create_instructor_entries(instructor_name)
-        updated_lookup <- rbind(current_lookup, instructor_entry)
-        safe_update_lookup_file(updated_lookup, lookup_file)
-        cat("✅ Added participant_type column and instructor configuration (preserved existing entries).\n")
+        cat("⚠️  Lookup file missing participant_type column.\n")
+        
+        # Check if the file is empty
+        if (nrow(current_lookup) == 0) {
+          cat("File is empty. Creating new lookup file with instructor configuration...\n")
+          instructor_entry <- create_instructor_entries(instructor_name)
+          safe_update_lookup_file(instructor_entry, lookup_file)
+          cat("✅ Created new lookup file with instructor configuration.\n")
+        } else {
+          cat("Adding participant_type and instructor configuration (preserving existing entries)...\n")
+          current_lookup$participant_type <- "enrolled_student"  # Default for existing entries
+          instructor_entry <- create_instructor_entries(instructor_name)
+          updated_lookup <- rbind(current_lookup, instructor_entry)
+          safe_update_lookup_file(updated_lookup, lookup_file)
+          cat("✅ Added participant_type column and instructor configuration (preserved existing entries).\n")
+        }
       }
     }
     


### PR DESCRIPTION
## Fixes Empty Lookup File Error

**Problem**: Error occurred when  exists but is empty (0 rows):



### **Root Cause**
The workflow was trying to add a  column to an empty data frame, which causes an error because you can't assign a value to a column in a 0-row data frame.

### **Solution Implemented**

Added checks for empty data frames in both problematic sections:

#### **1. Step 2 (Configure Instructor Names)**
- **Check if  has 0 rows**
- **Empty file**: Create new file with instructor configuration
- **Non-empty file**: Preserve existing entries and add  column

#### **2. Step 6.2 (Privacy-Aware Name Matching)**
- **Check if  has 0 rows**
- **Empty file**: Create new file with instructor configuration  
- **Non-empty file**: Preserve existing entries and add  column

### **Changes Made**

**Before**:
branch 'fix/empty-lookup-file-handling' set up to track 'origin/fix/empty-lookup-file-handling'.

**After**:
branch 'fix/empty-lookup-file-handling' set up to track 'origin/fix/empty-lookup-file-handling'.

### **User Experience**
- ✅ **Empty files handled gracefully**
- ✅ **Non-empty files preserve existing entries**
- ✅ **Clear error messages** distinguish between empty and non-empty files
- ✅ **No more crashes** when lookup file is empty

### **Testing**
- ✅ R Markdown syntax validation passed
- ✅ Handles both empty and non-empty lookup files

This fix ensures the workflow works correctly in all scenarios, including when users have empty lookup files.