### PR TITLE
docs: Document transcript examples search findings - Closes #335

### DIFF
--- a/docs/development/AUDIT_LOG.md
+++ b/docs/development/AUDIT_LOG.md
@@ -2,7 +2,25 @@
 
 This log tracks findings, decisions, and progress during the 2024-06 codebase audit for the zoomstudentengagement R package.
 
-## Recent Updates (July 2025)
+## Recent Updates (August 2025)
+
+### Transcript Examples Search (Completed)
+- **Date:** August 2025
+- **Branch:** `cursor/find-and-organize-zoom-vtt-transcript-examples-0736`
+- **Issue:** #335 - Documentation: Transcript examples search and findings
+- **Action:** Searched for publicly available Zoom transcript files for testing
+- **Findings:**
+  - **GitHub Repository Searches**: Found 1,500+ repos mentioning "zoom transcript" in READMEs
+  - **Key Finding**: Most repositories are tools/libraries for working with Zoom, not actual transcript files
+  - **Privacy/Licensing Barriers**: Most educational institutions don't publish raw Zoom transcripts
+  - **Format Specificity**: Need Zoom's native format, not converted captions
+  - **Public Availability**: Most Zoom meetings are private or internal
+- **Decision:** Use existing synthetic data for package development (already sufficient)
+- **Infrastructure Created:**
+  - `inst/extdata/public_transcripts/` directory structure
+  - `FINDING_REAL_ZOOM_TRANSCRIPTS.md` with comprehensive search strategy
+  - Download scripts and documentation for public course sources
+- **Status:** ✅ COMPLETED - Branch to be closed, findings documented
 
 ### Issue Cleanup and Organization (Completed)
 - **Date:** July 2025


### PR DESCRIPTION
## Summary

This PR documents the findings from our search for publicly available Zoom transcript files for testing.

## Changes

- **AUDIT_LOG.md**: Added comprehensive entry documenting the transcript examples search work
- **Documentation**: Recorded search results, barriers, and decision rationale
- **Issue Link**: Closes #335

## Key Findings Documented

- **Search Results**: 1,500+ GitHub repos found, but mostly tools/libraries
- **Privacy Barriers**: Most institutions don't publish raw Zoom transcripts  
- **Licensing Issues**: Educational transcripts rarely publicly available
- **Format Requirements**: Need Zoom's native format, not converted captions
- **Decision**: Use existing synthetic data (already sufficient for package development)

## Work Completed

- Searched GitHub repositories for actual Zoom transcript files
- Investigated educational institution public repositories
- Documented barriers to finding publicly available transcripts
- Recorded decision to use existing test infrastructure

## Impact

This documentation ensures future developers understand why we're using existing synthetic data rather than pursuing additional "live" transcript sources.

## Labels
- `docs`
- `priority:low`
- `area:testing`