### PR TITLE
Ensure write_metrics creates parent directories

### DIFF
--- a/R/write_metrics.R
+++ b/R/write_metrics.R
@@ -5,6 +5,7 @@
 #' @param data A tibble to write.
 #' @param what One of c("engagement", "summary", "session_summary"). Controls default filename.
 #' @param path Output file path. If missing, a default name is chosen based on `what` in the current dir.
+#'   Parent directories are created if they do not exist.
 #' @param comments_format For list-like `comments` columns: one of c("text", "count"). Default: "text".
 #' @param privacy_level Privacy level forwarded to `ensure_privacy()`. Default from option.
 #'
@@ -68,7 +69,10 @@ write_metrics <- function(
     )
     path <- fname
   }
-
+  dir_path <- dirname(path)
+  if (!dir.exists(dir_path)) {
+    dir.create(dir_path, recursive = TRUE)
+  }
   utils::write.csv(export_data, path, row.names = FALSE)
   invisible(export_data)
 }

--- a/man/write_metrics.Rd
+++ b/man/write_metrics.Rd
@@ -17,7 +17,8 @@ write_metrics(
 
 \item{what}{One of c("engagement", "summary", "session_summary"). Controls default filename.}
 
-\item{path}{Output file path. If missing, a default name is chosen based on \code{what} in the current dir.}
+\item{path}{Output file path. If missing, a default name is chosen based on \code{what} in the current dir.
+Parent directories are created if they do not exist.}
 
 \item{comments_format}{For list-like \code{comments} columns: one of c("text", "count"). Default: "text".}
 

--- a/tests/testthat/test-write_metrics-dir.R
+++ b/tests/testthat/test-write_metrics-dir.R
@@ -1,0 +1,9 @@
+test_that("write_metrics creates directories for nested paths", {
+  df <- tibble::tibble(preferred_name = "Alice", section = "101", n = 1)
+  tmp_dir <- tempfile()
+  tmp_file <- file.path(tmp_dir, "subdir", "metrics.csv")
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+  out <- write_metrics(df, what = "engagement", path = tmp_file)
+  expect_true(file.exists(tmp_file))
+  expect_s3_class(out, "tbl_df")
+})


### PR DESCRIPTION
## Summary
- create missing directories before writing output files
- document directory creation in `write_metrics`
- test writing to nested output paths

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8a78e680833183b0c5089a0a0d46