### PR TITLE
docs: update tibble references

### DIFF
--- a/R/load_transcript_files_list.R
+++ b/R/load_transcript_files_list.R
@@ -1,6 +1,6 @@
 #' Load Zoom Recording Transcript Files List
 #'
-#' This function creates a data.table from a provided folder including
+#' This function creates a tibble from a provided folder including
 #' transcript files of Zoom recordings.
 #'
 #' ## Download Transcripts
@@ -35,7 +35,7 @@
 #' @param start_time_local_tzone Local time zone of the recording start time of
 #'   the transcript. Defaults to `America/Los_Angeles`
 #'
-#' @return A data.frame listing the transcript files from the zoom recordings
+#' @return A tibble listing the transcript files from the zoom recordings
 #'   loaded from the cloud recording csvs and transcripts.
 #' @export
 #'

--- a/man/load_transcript_files_list.Rd
+++ b/man/load_transcript_files_list.Rd
@@ -48,11 +48,11 @@ recording start time of the transcript. Defaults to \verb{\\\%Y\\\%m\\\%d-\\\%H\
 the transcript. Defaults to \code{America/Los_Angeles}}
 }
 \value{
-A data.frame listing the transcript files from the zoom recordings
+A tibble listing the transcript files from the zoom recordings
 loaded from the cloud recording csvs and transcripts.
 }
 \description{
-This function creates a data.table from a provided folder including
+This function creates a tibble from a provided folder including
 transcript files of Zoom recordings.
 }
 \details{


### PR DESCRIPTION
## Summary
- clarify load_transcript_files_list docs to describe tibble outputs

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8baebe50833180e4000ce8e79232