### PR TITLE
Add guard for invalid metrics

### DIFF
--- a/R/mask_user_names_by_metric.R
+++ b/R/mask_user_names_by_metric.R
@@ -60,6 +60,9 @@ mask_user_names_by_metric <-
 
     if (tibble::is_tibble(df)) {
       # Use base R operations instead of dplyr to avoid segmentation fault
+      if (!metric %in% names(df)) {
+        stop(sprintf("Metric '%s' not found in data", metric), call. = FALSE)
+      }
       metric_col <- df[[metric]]
 
       # Handle NA values by replacing with -Inf for sorting

--- a/tests/testthat/test-mask_user_names_by_metric.R
+++ b/tests/testthat/test-mask_user_names_by_metric.R
@@ -27,3 +27,11 @@ test_that("mask_user_names_by_metric handles empty input", {
   expect_s3_class(result, "tbl_df")
   expect_equal(nrow(result), 0)
 })
+
+test_that("mask_user_names_by_metric errors when metric is missing", {
+  df <- tibble::tibble(preferred_name = c("Alice"), session_ct = c(5))
+  expect_error(
+    mask_user_names_by_metric(df, metric = "duration"),
+    "Metric 'duration' not found in data"
+  )
+})


### PR DESCRIPTION
## Summary
- add explicit check for metric column existence before use
- cover missing metric with new unit test

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ba2f27c83319c2861d4ba5533c0