### PR TITLE
docs(pr-process): document temporary CI block and local-validation self-merge policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,12 +78,12 @@ docs(readme): update installation instructions
 - [ ] **Merge Readiness**: Conflicts resolved, CI passing
 - [ ] **Project Alignment**: Supports CRAN submission goals
 
-#### Temporary CI Policy (until CI is unblocked)
+#### Temporary CI Policy (until CI is unblocked) — see Issue #406
 - CI is currently blocked. During this period, maintainers may self-merge their own PRs if BOTH of the following succeed locally:
   - `Rscript scripts/pre-pr-validation.R`
   - `./scripts/save-context.sh`
 - Document the successful runs in the PR description or as a review comment.
-- When CI is restored, this temporary policy will be removed and normal CI gating will resume.
+- When CI is restored, this temporary policy will be removed and normal CI gating will resume. Track at Issue #406.
 
 ### Decision Criteria
 - **APPROVE**: Meets all criteria, ready for merge
@@ -94,7 +94,7 @@ docs(readme): update installation instructions
 - **Clean Merge**: Standard process, no conflicts
 - **Merge Conflicts**: Rebase required before merge
 - **Branch Protection**: Use admin override when appropriate
-- **CI Pending / Blocked**: While CI is blocked, self-merge is allowed if `scripts/pre-pr-validation.R` and `scripts/save-context.sh` both complete successfully locally and results are recorded in the PR.
+- **CI Pending / Blocked**: While CI is blocked (Issue #406), self-merge is allowed if `scripts/pre-pr-validation.R` and `scripts/save-context.sh` both complete successfully locally and results are recorded in the PR.
 
 ### Time Estimates
 - **Low**: <10 files, documentation (10-15 min)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -76,12 +76,12 @@
 2. **Check CRAN Compliance**: Review [CRAN_SUBMISSION.md](CRAN_SUBMISSION.md)
 3. **Update Documentation**: Ensure all changes are documented
 
-#### Temporary CI Policy (until CI is unblocked)
+#### Temporary CI Policy (until CI is unblocked) — see Issue #406
 - CI is currently blocked. During this period, maintainers may self-merge their own PRs if BOTH of the following succeed locally:
   - `Rscript scripts/pre-pr-validation.R`
   - `./scripts/save-context.sh`
 - Document the successful runs in the PR description or as a review comment.
-- When CI is restored, this temporary policy will be removed and normal CI gating will resume.
+- When CI is restored, this temporary policy will be removed and normal CI gating will resume. Track at Issue #406.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document that CI is currently blocked
- Clarify that maintainers may self-merge their own PRs when both local validations succeed:
  - `Rscript scripts/pre-pr-validation.R`
  - `./scripts/save-context.sh`
- Require recording successful runs in PR description or review comment
- Note that policy is temporary and normal CI gating resumes when restored

## Files Updated
- CONTRIBUTING.md
- docs/development/README.md

## Rationale
- Aligns docs with current repo state and agreed workflow
- Provides clear, auditable criteria for safe merges while CI is blocked

## Validation
- N/A (docs change)