### PR TITLE
Add lintr config and best practices audit

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,5 @@
+linters: lintr::with_defaults(
+  line_length_linter = lintr::line_length_linter(100),
+  object_name_linter = lintr::object_name_linter(styles = "snake_case")
+)
+encoding: "UTF-8"

--- a/docs/best_practices_audit.md
+++ b/docs/best_practices_audit.md
@@ -1,0 +1,29 @@
+# Best Practices Audit
+
+This document summarizes the audit of the `zoomstudentengagement` package against modern R package best practices.
+
+## Tidyverse Style
+- The repository uses tidyverse-friendly code but lacked a project-wide linter configuration.  A new `.lintr` file now enforces line lengths and snake_case naming to encourage consistent style.
+- Consider running `lintr::lint_package()` locally or in CI to catch style issues before commits.
+
+## CRAN Readiness
+- The `DESCRIPTION` file includes required metadata, imports, suggests, and indicates roxygen2 usage and testthat edition 3.
+- GitHub Actions run `R CMD check` across macOS, Windows, and Linux, which supports cross-platform CRAN checks.
+- Numerous backup files are present; ensure they remain excluded from builds via `.Rbuildignore` to avoid CRAN warnings.
+
+## Testthat Coverage
+- Extensive tests exist under `tests/testthat`, and a coverage workflow enforces 90% threshold using `covr`.
+- R was not available in the execution environment, preventing running the tests during this audit.  Confirm locally that `devtools::test()` and the coverage workflow succeed.
+
+## Roxygen2 Documentation
+- Functions are documented with roxygen2 comments and `Roxygen: list(markdown = TRUE)` is set in `DESCRIPTION`.
+- Some examples are minimal placeholders; expanding runnable examples would improve documentation quality.
+
+## CI/CD
+- Workflows are defined for linting, test coverage, and cross-platform checks.  They install dependencies, generate documentation, and fail on coverage below 90%.
+- Ensure workflows finish with trailing newlines to avoid YAML parsing issues.
+
+## Recommendations
+- Run lintr, tests, and R CMD check regularly to maintain CRAN readiness.
+- Gradually enhance examples and vignettes for end users.
+- Continue monitoring CI for redundancy; remove obsolete workflows if they no longer add value.


### PR DESCRIPTION
## Summary
- add tidyverse-oriented `.lintr` configuration
- document audit findings in `docs/best_practices_audit.md`

## Testing
- `R -q -e 'lintr::lint_package()'` *(fails: R not installed)*
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aea1172634833194f5d9801bf3ff26