### PR TITLE
refactor process_zoom_transcript

### DIFF
--- a/docs/development/AUDIT_LOG.md
+++ b/docs/development/AUDIT_LOG.md
@@ -4,6 +4,13 @@ This log tracks findings, decisions, and progress during the 2024-06 codebase au
 
 ## Recent Updates (August 2025)
 
+### Process Zoom Transcript Refactor (Tactical)
+- **Date:** August 2025
+- **Change:** Simplified `process_zoom_transcript()` by removing redundant variables and pipes while adding explicit input handling.
+- **Debt Addressed:** Reduced unnecessary complexity and fragile scoping.
+- **Type:** Tactical
+- **Status:** ✅ Completed
+
 ### Transcript Examples Search (Completed)
 - **Date:** August 2025
 - **Branch:** `cursor/find-and-organize-zoom-vtt-transcript-examples-0736`


### PR DESCRIPTION
## Summary
- simplify `process_zoom_transcript()` by removing redundant variables and pipes and by validating inputs early
- document the refactor in the audit log

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not found)*
- `apt-get update` *(fails: repository 403)*
- `apt-get install -y r-base` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aea13b6ed4833180f145979d39e3cd