### PR TITLE
[zoomstudentengagement] Process: add pre-commit hooks + project log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: mixed-line-ending
+      - id: check-added-large-files
+
+  # Local hook to style and lint R/Rmd files using existing script
+  - repo: local
+    hooks:
+      - id: r-style-and-lint
+        name: Style and lint R files (styler/lintr)
+        entry: bash scripts/pre-commit.sh
+        language: system
+        pass_filenames: false
+        files: "\\.(R|r|Rmd)$"
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,40 @@ devtools::check()                    # Full package check
 devtools::build()                    # Create distributable package
 ```
 
+### Pre-commit Hooks (Recommended)
+
+Keep your changes clean by running formatting and linting automatically before
+each commit using pre-commit hooks.
+
+Setup (one time):
+
+```bash
+# Install pre-commit (choose one)
+brew install pre-commit             # macOS
+pipx install pre-commit             # Python toolchain (recommended)
+python3 -m pip install --user pre-commit
+
+# Install R dependencies used by the hooks
+Rscript -e "install.packages(c('styler','lintr','roxygen2','spelling'), dep = TRUE)"
+
+# Install the hooks defined in .pre-commit-config.yaml
+pre-commit install
+
+# Optional: run hooks across the entire repo once
+pre-commit run --all-files
+```
+
+What runs:
+- Base hygiene hooks: trailing whitespace, EOF fixer, YAML checks
+- Local R hook via `scripts/pre-commit.sh` that:
+  - Styles staged `.R`/`.Rmd` files using `styler`
+  - Lints staged files using `lintr` and fails on lint
+
+Notes:
+- If a hook modifies files (e.g., styling), re-stage and commit.
+- Keep `styler`/`lintr` versions current to match CI behavior.
+
+
 ### Diagnostic Output Policy
 
 - Default to quiet output. Provide a `verbose = FALSE` argument for functions that may emit diagnostics.

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -1,0 +1,23 @@
+# Project Log
+
+This log documents improvement cycles (bugs, debt, metrics, visuals) and any
+process improvements implemented to make the repository easier to maintain.
+
+## 2025-08-28 — Process Improvements: Pre-commit + Contribution Workflow
+
+- Added `.pre-commit-config.yaml` with:
+  - Base hygiene hooks (trailing whitespace, EOF, YAML, mixed line endings)
+  - Local hook delegating to `scripts/pre-commit.sh` to run `styler` and `lintr`
+- Updated `CONTRIBUTING.md` with pre-commit setup and usage instructions
+- Established this `docs/project_log.md` to record future improvement cycles
+
+Why this matters:
+- Standardizes formatting and linting before commits to reduce CI churn
+- Gives contributors a clear, repeatable pre-PR workflow
+- Creates an auditable history of process improvements
+
+How to test:
+- Install hooks with `pre-commit install`
+- Run on all files with `pre-commit run --all-files`
+- Make a small edit to an `.R` file and commit to see styling/lint enforced
+

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -9,13 +9,32 @@ if [ -z "$STAGED_FILES" ]; then
   exit 0
 fi
 
-echo "Styling staged R files with styler..."
-Rscript -e "styler::style_files(command = 'R CMD', filetype = c('R', 'Rmd'), strict = FALSE, transformers = styler::tidyverse_style(), filefilter = function(paths) paths[paths %in% strsplit(Sys.getenv('STAGED'), '\\n')[[1]]])" \
-  --vanilla --args
-
 export STAGED="$STAGED_FILES"
 
+echo "Styling staged R files with styler..."
+Rscript --vanilla -e "
+  files <- strsplit(Sys.getenv('STAGED'), '\n')[[1]]
+  files <- files[nzchar(files)]
+  if (length(files) > 0) {
+    styler::style_file(files, transformers = styler::tidyverse_style(), cache = FALSE)
+  }
+"
+
+# Re-stage files that may have been modified by styler (skippable in sandboxes)
+if [ "${SKIP_RESTAGE:-}" != "1" ]; then
+  git add $STAGED_FILES
+fi
+
 echo "Running lintr on staged files..."
-Rscript -e "lintr::lint(File = strsplit(Sys.getenv('STAGED'), '\\n')[[1]], error_on_lint = TRUE)"
+Rscript --vanilla -e "
+  files <- strsplit(Sys.getenv('STAGED'), '\n')[[1]]
+  files <- files[nzchar(files)]
+  lints <- unlist(lapply(files, lintr::lint))
+  if (length(lints) > 0) {
+    print(lints)
+    quit(status = 1)
+  }
+  cat('No lints found.\n')
+"
 
 echo "Done."


### PR DESCRIPTION
What changed
- Added `.pre-commit-config.yaml` with:
  - pre-commit hygiene hooks (trailing whitespace, EOF fixer, YAML checks)
  - local R hook via `scripts/pre-commit.sh` running `styler` and `lintr` on staged `.R`/`.Rmd`
- Updated `CONTRIBUTING.md` with pre-commit setup/usage instructions
- Added `docs/project_log.md` to record improvement cycles
- Minor fixes to `scripts/pre-commit.sh` (styler cache off, safe restaging, lint runner)

Why it matters
- Ensures consistent formatting and linting pre-commit, reducing CI churn
- Gives contributors a clear, repeatable workflow and improves DX
- Establishes an auditable record of process improvements

How to test
1) Install hooks and deps:
   - `brew install pre-commit` or `pipx install pre-commit`
   - `Rscript -e "install.packages(c('styler','lintr'), dep = TRUE)"`
2) `pre-commit install`
3) `pre-commit run --all-files`
4) Edit an `.R` file and commit; verify styling/linting run

Pre-PR validation summary (local)
- devtools::test(): PASS
- Documentation update: PASS
- README build, vignettes, and full `devtools::check()`: blocked by sandbox (processx op not permitted)
- Shell scripts: a few not executable warnings (unchanged by this PR); `scripts/pre-commit.sh` now passes

Scope
- No changes to package functionality or `man/`; docs-only and tooling

