### PR TITLE
[zoomstudentengagement] Add CRAN release plan

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,6 +16,7 @@ A comprehensive PRD audit was completed with **ACTIONABLE FINDINGS** for package
 - `docs/implementation/PRD_AUDIT_IMPLEMENTATION_PLAN.md` - Comprehensive implementation plan
 - `docs/implementation/HYBRID_APPROACH_IMPLEMENTATION_GUIDE.md` - Strategic approach
 - `docs/implementation/INITIATIVE_1_SUCCESS_METRICS_DETAILED_PLAN.md` - Success metrics foundation
+- `docs/planning/CRAN_RELEASE_PLAN.md` - Step-by-step plan for initial CRAN submission
 
 ### 🔒 **Security and Performance Review Integration (COMPLETED - 2025-08-25)**
 A comprehensive security and performance review was completed with **EXCELLENT results**:

--- a/docs/planning/CRAN_RELEASE_PLAN.md
+++ b/docs/planning/CRAN_RELEASE_PLAN.md
@@ -1,0 +1,24 @@
+# CRAN Release Plan
+
+**Last updated:** 2025-09-01
+
+This document outlines the minimal steps required to submit `zoomstudentengagement` version 0.1.0 to CRAN.
+
+1. **Trim and stabilize the public API**
+   - Internalize non-essential helpers and target a concise exported surface (~16 core functions).
+
+2. **Prepare package metadata for a 0.1.0 release**
+   - Update `DESCRIPTION` to Version 0.1.0 and add a matching `NEWS.md` entry documenting the initial release.
+
+3. **Resolve outstanding quality issues**
+   - Raise test coverage above 90%, fix all `R CMD check` notes, and eliminate test warnings.
+
+4. **Refresh user documentation**
+   - Restructure `README.Rmd`, ensure vignettes reflect the pared-down API, and regenerate documentation with `roxygen2`.
+
+5. **Run full pre-submission checks and build**
+   - Format with `styler`, lint with `lintr`, then run `devtools::document()`, `devtools::test()`, `covr::package_coverage()`, `devtools::check()`, and `devtools::build()`.
+
+6. **Tag and submit**
+   - Tag release (`v0.1.0`), create `cran-comments.md`, submit via CRAN's web form, and monitor for reviewer feedback.
+


### PR DESCRIPTION
## Summary
- Document CRAN release plan with steps for 0.1.0 submission
- Reference new plan from project overview

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not installed)*
- `Rscript scripts/pre-pr-validation.R` *(fails: Rscript not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b33da45364833180c1a15028cfc103