### PR TITLE
fix: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,7 +36,7 @@ jobs:
         Rscript scripts/benchmark-ideal-transcripts.R 3 benchmark_results.rds
     
     - name: Upload benchmark results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmark-results-${{ matrix.r-version }}
         path: benchmark_results.rds


### PR DESCRIPTION
## Problem
Performance Tests workflow was failing due to deprecated action:
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`
```

## Solution
- Updated `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
- Resolves GitHub Actions deprecation error
- Ensures workflow compatibility with current GitHub Actions

## Changes
- Updated upload-artifact action version in `.github/workflows/performance.yml`

Fixes: Performance Tests workflow failure