### PR TITLE
fix: Add system dependencies for R package installation

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -22,6 +22,11 @@ jobs:
       with:
         r-version: ${{ matrix.r-version }}
     
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+    
     - name: Install dependencies
       run: |
         Rscript -e "install.packages(c('remotes', 'testthat', 'microbenchmark', 'pryr'))"


### PR DESCRIPTION
## Problem
Performance Tests workflow was failing because `devtools` package couldn't be installed due to missing system dependencies:
```
Error in loadNamespace(x) : there is no package called 'devtools'
ERROR: dependency 'curl' is not available for package 'httr2'
```

## Root Cause
The workflow was missing system-level dependencies required for R packages that depend on curl, SSL, and XML libraries.

## Solution
- Added system dependency installation step before R package installation
- Installs `libcurl4-openssl-dev`, `libssl-dev`, `libxml2-dev`
- Ensures all R package dependencies can be installed properly

## Changes
- Added `Install system dependencies` step in `.github/workflows/performance.yml`
- Installs required system packages before R package installation

Fixes: Performance Tests workflow failure due to missing system dependencies