### PR TITLE
fix: Add devtools to performance workflow dependencies

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        Rscript -e "install.packages(c('remotes', 'testthat', 'microbenchmark', 'pryr'))"
+        Rscript -e "install.packages(c('remotes', 'testthat', 'microbenchmark', 'pryr', 'devtools'))"
     
     - name: Run benchmarks
       run: |


### PR DESCRIPTION
## Problem
Performance Tests workflow was failing with missing devtools package:
```
Error in benchmark_ideal_transcripts(iterations = iterations, output_file = output_file) : 
  devtools package is required for development mode
```

## Root Cause
The benchmark script requires `devtools::load_all()` functionality but we removed devtools from the workflow dependencies in the previous fix.

## Solution
- Add `devtools` package to essential dependencies list
- Maintains minimal dependency approach while including necessary packages
- Ensures benchmark script can run successfully

## Changes
- Updated dependency installation in `.github/workflows/performance.yml`
- Added devtools to the list of essential packages

Fixes: Performance Tests workflow failure due to missing devtools package