### PR TITLE
fix: Disable performance workflow for CRAN submission

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,42 +1,47 @@
-name: Performance Tests
+# Performance Tests workflow - DISABLED for CRAN submission
+# This workflow is disabled because:
+# 1. Performance testing is not required for CRAN submission
+# 2. The benchmark script requires devtools::load_all() which installs all dependencies
+# 3. This causes CI timeouts due to heavy dependency compilation
+# 4. Performance testing should be done locally during development
+#
+# To re-enable this workflow for local development:
+# 1. Uncomment the workflow below
+# 2. Run locally: Rscript scripts/benchmark-ideal-transcripts.R
+# 3. Or create a separate development-only workflow
 
-on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  performance:
-    runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        r-version: [4.1, 4.2, 4.3]
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up R
-      uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: ${{ matrix.r-version }}
-    
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
-    
-    - name: Install dependencies
-      run: |
-        Rscript -e "install.packages(c('remotes', 'testthat', 'microbenchmark', 'pryr', 'devtools'))"
-    
-    - name: Run benchmarks
-      run: |
-        Rscript scripts/benchmark-ideal-transcripts.R 3 benchmark_results.rds
-    
-    - name: Upload benchmark results
-      uses: actions/upload-artifact@v4
-      with:
-        name: benchmark-results-${{ matrix.r-version }}
-        path: benchmark_results.rds
+# name: Performance Tests
+# 
+# on:
+#   workflow_dispatch:  # Manual trigger only
+# 
+# jobs:
+#   performance:
+#     runs-on: ubuntu-latest
+#     
+#     steps:
+#     - uses: actions/checkout@v3
+#     
+#     - name: Set up R
+#       uses: r-lib/actions/setup-r@v2
+#       with:
+#         r-version: 4.3
+#     
+#     - name: Install system dependencies
+#       run: |
+#         sudo apt-get update
+#         sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+#     
+#     - name: Install dependencies
+#       run: |
+#         Rscript -e "install.packages(c('remotes', 'testthat', 'microbenchmark', 'pryr', 'devtools'))"
+#     
+#     - name: Run benchmarks
+#       run: |
+#         Rscript scripts/benchmark-ideal-transcripts.R 3 benchmark_results.rds
+#     
+#     - name: Upload benchmark results
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: benchmark-results
+#         path: benchmark_results.rds

--- a/scripts/run-performance-tests-locally.R
+++ b/scripts/run-performance-tests-locally.R
@@ -1,0 +1,60 @@
+#!/usr/bin/env Rscript
+
+#' Local Performance Testing Script
+#' 
+#' This script runs performance tests locally without the overhead of CI/CD.
+#' It's designed for development use and can be run when performance testing is needed.
+#' 
+#' Usage:
+#'   Rscript scripts/run-performance-tests-locally.R [iterations] [output_file]
+#' 
+#' Examples:
+#'   Rscript scripts/run-performance-tests-locally.R
+#'   Rscript scripts/run-performance-tests-locally.R 10 performance_results.rds
+
+# Check if we're in the right directory
+if (!file.exists("DESCRIPTION")) {
+  stop("Please run this script from the package root directory")
+}
+
+# Check if required packages are available
+required_packages <- c("devtools", "microbenchmark", "pryr")
+missing_packages <- required_packages[!sapply(required_packages, requireNamespace, quietly = TRUE)]
+
+if (length(missing_packages) > 0) {
+  cat("Installing missing packages:", paste(missing_packages, collapse = ", "), "\n")
+  install.packages(missing_packages)
+}
+
+# Load the benchmark script
+source("scripts/benchmark-ideal-transcripts.R")
+
+# Get command line arguments
+args <- commandArgs(trailingOnly = TRUE)
+iterations <- if (length(args) >= 1) as.numeric(args[1]) else 5
+output_file <- if (length(args) >= 2) args[2] else "local_performance_results.rds"
+
+cat("=== LOCAL PERFORMANCE TESTING ===\n")
+cat("Package:", read.dcf("DESCRIPTION")[1, "Package"], "\n")
+cat("Version:", read.dcf("DESCRIPTION")[1, "Version"], "\n")
+cat("Iterations:", iterations, "\n")
+cat("Output file:", output_file, "\n")
+cat("Timestamp:", as.character(Sys.time()), "\n\n")
+
+# Run the benchmarks
+tryCatch({
+  results <- benchmark_ideal_transcripts(
+    iterations = iterations,
+    output_file = output_file
+  )
+  
+  cat("\n=== PERFORMANCE TESTING COMPLETED SUCCESSFULLY ===\n")
+  cat("Results saved to:", output_file, "\n")
+  
+}, error = function(e) {
+  cat("\n=== PERFORMANCE TESTING FAILED ===\n")
+  cat("Error:", e$message, "\n")
+  cat("This is expected if the package is not in development mode.\n")
+  cat("Try running: devtools::load_all() first, or install the package.\n")
+  quit(status = 1)
+})


### PR DESCRIPTION
## Problem
Performance Tests workflow was causing CI timeouts during CRAN submission preparation:
- Benchmark script requires `devtools::load_all()` which installs ALL dependencies
- This includes heavy packages like `shiny`, `rmarkdown`, `gert`, etc.
- CI timeouts due to dependency compilation taking >10 minutes
- Performance testing is not required for CRAN submission

## Solution
- **Disable Performance Tests workflow** for CRAN submission
- **Keep performance testing available** for local development
- **Add local performance testing script** for development use
- **Focus CI on CRAN-required workflows**: R CMD check, coverage, linting

## Changes
- Disabled Performance Tests workflow (commented out with explanation)
- Added `scripts/run-performance-tests-locally.R` for local development
- Maintains performance testing capability without CI overhead

## Benefits
- ✅ **Eliminates CI timeouts** - no more heavy dependency compilation
- ✅ **Faster CI/CD** - focuses on CRAN-required checks only
- ✅ **Maintains development workflow** - performance testing still available locally
- ✅ **CRAN-ready** - removes unnecessary dependencies from CI

## Usage
For local performance testing:
```bash
Rscript scripts/run-performance-tests-locally.R
```

Fixes: CI timeout issues during CRAN submission preparation