### PR TITLE
docs: hide FERPA vignette setup chunk

### DIFF
--- a/vignettes/ferpa-ethics.Rmd
+++ b/vignettes/ferpa-ethics.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```r
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 ```
 


### PR DESCRIPTION
## Summary

- Hide the FERPA/privacy vignette setup chunk from rendered HTML.
- Keep the current privacy-supporting / no-legal-guarantee wording intact.

## Validation

- Rendered `vignettes/ferpa-ethics.Rmd` successfully.
- `devtools::check(args = c("--no-manual", "--as-cran"), error_on = "never")`: 0 errors, 0 warnings, 0 notes.
- `R CMD build .`: passed.
- Inspected `engager_0.1.0.tar.gz` rendered vignette: setup chunk absent; no old compliance-guarantee phrasing found.
- Tarball suspicious-path scan: no hits.

## Notes

The browser page at `/Users/piper/git/zoomstudentengagement/doc/ferpa-ethics.html` is a stale ignored local artifact. The CRAN tarball uses the rebuilt vignette under `inst/doc/`.
