### PR TITLE
fix: repair pre-CRAN release workflows

### DIFF
--- a/R/analyze_multi_session_attendance.R
+++ b/R/analyze_multi_session_attendance.R
@@ -1,7 +1,8 @@
 #' Analyze Multi-Session Attendance Patterns
 #'
 #' Analyzes attendance patterns across multiple Zoom sessions, tracking who attended
-#' which sessions and identifying participation patterns while maintaining privacy compliance.
+#' which sessions and identifying participation patterns while applying the
+#' selected package masking controls.
 #'
 #' @param transcript_files Vector of transcript file paths to analyze
 #' @param roster_data Data frame containing student roster information
@@ -16,7 +17,9 @@
 #'   - `attendance_summary`: Summary statistics for each participant
 #'   - `session_summary`: Summary statistics for each session
 #'   - `participation_patterns`: Analysis of participation patterns
-#'   - `privacy_compliant`: Boolean indicating if all outputs maintain privacy
+#'   - `privacy_compliant`: Backward-compatible Boolean indicating whether the
+#'     package's technical privacy checks completed without an error. This is
+#'     not a legal or institutional compliance determination.
 #'
 #' @examples
 #' # Analyze attendance across multiple sessions
@@ -170,7 +173,7 @@ analyze_multi_session_attendance <- function(
     attendance_rate_std = round(stats::sd(attendance_rates) * 100, 1)
   )
 
-  # Validate privacy compliance
+  # Run the package's technical privacy checks.
   privacy_compliant <- TRUE
   tryCatch(
     {
@@ -257,12 +260,12 @@ generate_attendance_report <- function(
     paste("- **Median Attendance Rate**:", patterns$median_attendance_rate, "%"),
     paste("- **Attendance Rate Std Dev**:", patterns$attendance_rate_std, "%"),
     "",
-    "## Privacy Compliance",
+    "## Technical Privacy Check",
     "",
     if (analysis_results$privacy_compliant) {
-      "[PASS] All outputs maintain privacy compliance"
+      "[PASS] Package masking checks completed"
     } else {
-      "[FAIL] Privacy violations detected"
+      "[FAIL] Package masking checks detected possible identifiers"
     },
     ""
   )

--- a/R/ensure_privacy.R
+++ b/R/ensure_privacy.R
@@ -11,7 +11,8 @@
 #'
 #' The default behavior is controlled by the global option
 #' `engager.privacy_level`, which is set to "mask" on package
-#' load. Use `set_privacy_defaults()` to change at runtime.
+#' load. Pass `privacy_level` explicitly for one call, or set the
+#' `engager.privacy_level` option for the current R session.
 #'
 #' @param x Data object to apply privacy rules to (typically a `tibble`)
 #' @param privacy_level Privacy level: "mask", "privacy_strict",
@@ -19,7 +20,8 @@
 #'   "ferpa_standard" are accepted with a warning.
 #' @param id_columns Vector of column names to treat as identifiers (default: common name columns)
 #' @param audit_log Whether to log privacy operations (default: TRUE)
-#' @return Privacy-compliant version of the input object
+#' @return A privacy-processed version of the input object. This is a technical
+#'   masking result, not a legal or institutional compliance determination.
 #'
 #' df <- tibble::tibble(
 #'   section = c("A", "A", "B"),

--- a/R/ethical_compliance.R
+++ b/R/ethical_compliance.R
@@ -1,8 +1,8 @@
-#' Ethical Compliance Functions
+#' Ethical Review Functions
 #'
-#' Comprehensive ethical compliance tools for educational data analysis.
-#' These functions ensure the package promotes participation equity rather than
-#' surveillance and maintains the highest ethical standards for educational research.
+#' Internal technical prompts for reviewing educational data-analysis use.
+#' These helpers do not determine whether a workflow is ethically approved or
+#' compliant with institutional requirements.
 #'
 #' @name ethical_compliance
 NULL
@@ -122,13 +122,13 @@ validate_ethical_use <- function(usage_context = c("research", "teaching", "asse
     )
   } else {
     result$required_documentation <- c(
-      "Basic privacy compliance documentation"
+      "Basic privacy review documentation"
     )
   }
 
   # Institutional guidance
   result$institutional_guidance <- c(
-    "Ensure all data handling complies with institutional policies",
+    "Review data handling against applicable institutional policies",
     "Consult with institutional privacy officer if uncertain",
     "Document all data processing and analysis procedures",
     "Regularly review and update privacy safeguards"

--- a/R/privacy_review.R
+++ b/R/privacy_review.R
@@ -139,7 +139,7 @@ review_privacy_risks <- function(data = NULL,
   # Additional privacy review recommendations
   result$recommendations <- c(
     result$recommendations,
-    "Use set_privacy_defaults('mask') for privacy-safe outputs",
+    "Use ensure_privacy(..., privacy_level = 'mask') or write_metrics(..., privacy_level = 'mask') for masked outputs",
     "Implement secure data storage and transmission",
     "Train personnel on applicable privacy requirements",
     "Maintain audit trails for data access and modifications"
@@ -451,12 +451,12 @@ generate_ferpa_report <- function(data = NULL,
   report
 }
 
-#' Check Data Retention Policy
+#' Review a Configured Data Retention Period
 #'
-#' Validates data retention policies and identifies data that should be
-#' disposed of according to institutional policies.
+#' Compares configured date fields with a selected period to support local
+#' records review. It does not determine or enforce institutional policy.
 #'
-#' @param data Data frame to check for retention policy compliance
+#' @param data Data frame to inspect for retention-period review
 #' @param retention_period Retention period: "academic_year", "semester", "quarter", or "custom"
 #' @param custom_retention_days Custom retention period in days (for "custom" period)
 #' @param date_column Column name containing dates to check

--- a/R/ux_basic_workflow.R
+++ b/R/ux_basic_workflow.R
@@ -83,7 +83,7 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
         analysis,
         metric = "wordcount",
         student_col = "name",
-        facet_by = if ("transcript_file" %in% names(analysis)) "transcript_file" else "none",
+        facet_by = "none",
         # `analysis` was already processed with the selected privacy level.
         # Avoid applying a second masking pass that would change stable labels.
         privacy_level = "none"

--- a/R/ux_basic_workflow.R
+++ b/R/ux_basic_workflow.R
@@ -8,9 +8,11 @@
 #' @description This is the main function for new users. It performs a complete
 #'   analysis workflow in 5 simple steps: load, process, analyze, visualize, and export.
 #'
-#' @param transcript_file Path to transcript file (VTT, TXT, or CSV format)
+#' @param transcript_file Path to a WebVTT transcript file
 #' @param output_dir Output directory for results (default: "output")
-#' @param privacy_level Privacy protection level: "high" (default), "medium", "low"
+#' @param privacy_level Privacy protection level: "high" (default), "medium",
+#'   or "low". These map to `"privacy_strict"`, `"privacy_standard"`, and
+#'   `"mask"`, respectively. All three levels mask common identifiers.
 #' @return List containing analysis results, plots, and output directory path
 #' @export
 #' @examples
@@ -35,8 +37,10 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
     dir.create(output_dir, recursive = TRUE)
   }
 
-  # Set privacy defaults
-  set_privacy_defaults()
+  normalized_privacy_level <- normalize_basic_privacy_level(privacy_level)
+  previous_privacy_level <- getOption("engager.privacy_level")
+  on.exit(options(engager.privacy_level = previous_privacy_level), add = TRUE)
+  options(engager.privacy_level = normalized_privacy_level)
 
   # TARGET: Starting Basic Transcript Analysis
   message("==> Starting Basic Transcript Analysis")
@@ -55,22 +59,47 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
 
       # Step 2: Process transcript
       message("Step 2/5: Processing transcript...")
-      processed <- process_zoom_transcript(transcript)
+      processed <- process_zoom_transcript(transcript_df = transcript)
+      if (!is.data.frame(processed) || nrow(processed) == 0) {
+        stop("Transcript processing returned no rows", call. = FALSE)
+      }
       message("SUCCESS: Processed transcript data")
 
       # Step 3: Analyze engagement
       message("Step 3/5: Analyzing engagement...")
-      analysis <- analyze_transcripts(processed)
+      analysis <- summarize_transcript_metrics(
+        transcript_df = processed,
+        names_exclude = c("dead_air"),
+        comments_format = "count"
+      )
+      if (!is.data.frame(analysis) || nrow(analysis) == 0) {
+        stop("Transcript analysis returned no engagement metrics", call. = FALSE)
+      }
       message("SUCCESS: Calculated engagement metrics")
 
       # Step 4: Create visualizations
       message("Step 4/5: Creating visualizations...")
-      plots <- plot_users(analysis)
+      plots <- plot_users(
+        analysis,
+        metric = "wordcount",
+        student_col = "name",
+        facet_by = if ("transcript_file" %in% names(analysis)) "transcript_file" else "none",
+        # `analysis` was already processed with the selected privacy level.
+        # Avoid applying a second masking pass that would change stable labels.
+        privacy_level = "none"
+      )
       message("SUCCESS: Created engagement visualizations")
 
       # Step 5: Export results
       message("Step 5/5: Exporting results...")
-      write_metrics(analysis, output_dir)
+      output_path <- file.path(output_dir, "engagement_metrics.csv")
+      write_metrics(
+        analysis,
+        what = "engagement",
+        path = output_path,
+        privacy_level = normalized_privacy_level,
+        comments_policy = "omit"
+      )
       message("SUCCESS: Exported results to ", output_dir)
 
       message("")
@@ -96,6 +125,24 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
       stop(e)
     }
   )
+}
+
+# Internal mapping retained for the beginner-facing high/medium/low API.
+normalize_basic_privacy_level <- function(privacy_level) {
+  if (!is.character(privacy_level) || length(privacy_level) != 1 || is.na(privacy_level)) {
+    stop('`privacy_level` must be one of: "high", "medium", "low"', call. = FALSE)
+  }
+
+  levels <- c(
+    high = "privacy_strict",
+    medium = "privacy_standard",
+    low = "mask"
+  )
+  if (!privacy_level %in% names(levels)) {
+    stop('`privacy_level` must be one of: "high", "medium", "low"', call. = FALSE)
+  }
+
+  unname(levels[[privacy_level]])
 }
 
 #' Quick analysis for single transcript file

--- a/R/ux_error_handling.R
+++ b/R/ux_error_handling.R
@@ -43,92 +43,92 @@ user_friendly_error <- function(expr, context = "operation") {
 convert_error_to_user_friendly <- function(error_message, context) {
   # Function not found errors
   if (grepl("could not find function|could not find object", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Function not found. This might be an advanced function.\n",
       "TIP: Try: set_ux_level('intermediate') to see more functions\n",
       "TIP: Or: show_function_help('function_name') for guidance\n",
       "TIP: Or: find_function_for_task('what you want to do') to find the right function"
-    )
+    ))
   }
 
   # File not found errors
   if (grepl("file not found|cannot open file|no such file", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: File not found. Please check the file path.\n",
       "TIP: Make sure the file exists and you have permission to read it\n",
       "TIP: Try: list.files() to see available files\n",
-      "TIP: Check file extension (.vtt, .txt, .csv are supported)"
-    )
+      "TIP: Check the function documentation for the expected file extension"
+    ))
   }
 
   # Permission denied errors
   if (grepl("permission denied|access denied|cannot open", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Permission denied. You don't have access to this file.\n",
       "TIP: Check file permissions or try a different file\n",
       "TIP: Try a different output directory\n",
       "TIP: Contact your system administrator if needed"
-    )
+    ))
   }
 
   # Memory errors
   if (grepl("memory|cannot allocate|out of memory", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Memory issue. The file might be too large.\n",
       "TIP: Try with a smaller file first\n",
       "TIP: Use batch processing for large datasets\n",
       "TIP: Check available system memory"
-    )
+    ))
   }
 
   # Data format errors
   if (grepl("invalid|malformed|parse error|format", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Data format issue. The file might be corrupted or in wrong format.\n",
-      "TIP: Check file format (VTT, TXT, CSV are supported)\n",
-      "TIP: Try: validate_schema() to check data structure\n",
+      "TIP: Confirm transcript inputs use valid WebVTT format\n",
+      "TIP: Try: show_function_help('load_zoom_transcript') for input requirements\n",
       "TIP: Use a different transcript file to test"
-    )
+    ))
   }
 
   # Network/connection errors
   if (grepl("connection|network|timeout|unreachable", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Connection issue. Network or server problem.\n",
       "TIP: Check your internet connection\n",
       "TIP: Try again in a few minutes\n",
       "TIP: Contact support if problem persists"
-    )
+    ))
   }
 
   # Package dependency errors
   if (grepl("package.*not found|library.*not found|namespace", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Missing package dependency.\n",
       "TIP: Try: install.packages('package_name')\n",
       "TIP: Or: devtools::install_deps() to install all dependencies\n",
       "TIP: Check package installation"
-    )
+    ))
   }
 
   # Argument errors
   if (grepl("argument|parameter|missing|required", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Function argument issue.\n",
       "TIP: Check function arguments and required parameters\n",
       "TIP: Try: show_function_help('function_name') for usage\n",
       "TIP: Or: find_function_for_task('what you want to do')"
-    )
+    ))
   }
 
   # Privacy/security errors
   if (grepl("privacy|security|access|unauthorized", error_message)) {
-    paste0(
+    return(paste0(
       "ERROR: Privacy or security issue.\n",
-      "TIP: Check privacy settings: set_privacy_defaults()\n",
-      "TIP: Use: ensure_privacy() to protect data\n",
+      "TIP: Check the engager.privacy_level option\n",
+      "TIP: Use: ensure_privacy(data, privacy_level = 'mask') to mask structured identifiers\n",
       "TIP: See: show_privacy_guidance() for help"
-    )
+    ))
   }
 
   # Default user-friendly message
@@ -169,7 +169,7 @@ validate_file_argument <- function(file_path, context = "file operation") {
     stop("ERROR: File not found: ", file_path, "\n",
       "TIP: Check the file path and try again\n",
       "TIP: Use list.files() to see available files\n",
-      "TIP: Make sure file has .vtt, .txt, or .csv extension",
+      "TIP: Check the function documentation for the expected file extension",
       call. = FALSE
     )
   }
@@ -235,7 +235,7 @@ show_error_recovery <- function(error_type) {
     "file_not_found" = {
       cat("TOOLS: File Not Found - Recovery Steps:\n")
       cat("1. Check file path: list.files() to see available files\n")
-      cat("2. Check file extension: .vtt, .txt, .csv are supported\n")
+      cat("2. Check the function documentation for the expected file extension\n")
       cat("3. Check working directory: getwd() to see current location\n")
       cat("4. Use full path: '/full/path/to/file.vtt'\n")
     },

--- a/R/ux_guidance_system.R
+++ b/R/ux_guidance_system.R
@@ -104,6 +104,8 @@ show_function_help <- function(function_name) {
   )
   if (length(documentation) == 0) {
     cat("   No documentation available\n")
+  } else {
+    print(documentation)
   }
 
   # Show usage examples for common functions

--- a/R/ux_guidance_system.R
+++ b/R/ux_guidance_system.R
@@ -13,8 +13,8 @@
 #' }
 show_getting_started <- function() {
   cat("
-Getting Started with zoomstudentengagement
-============================================
+Getting Started with engager
+============================
 
 BASIC WORKFLOW (5 steps):
 1. load_zoom_transcript() - Load your transcript file
@@ -28,10 +28,10 @@ QUICK START (Recommended for new users):
 
 STEP-BY-STEP WORKFLOW:
    transcript <- load_zoom_transcript('your_file.vtt')
-   processed <- process_zoom_transcript(transcript)
-   analysis <- analyze_transcripts(processed)
-   plots <- plot_users(analysis)
-   write_metrics(analysis, 'output/')
+   processed <- process_zoom_transcript(transcript_df = transcript)
+   analysis <- summarize_transcript_metrics(transcript_df = processed)
+   plots <- plot_users(analysis, metric = 'wordcount', facet_by = 'transcript_file')
+   write_metrics(analysis, path = 'output/engagement_metrics.csv')
 
 BATCH PROCESSING:
    files <- c('session1.vtt', 'session2.vtt')
@@ -50,7 +50,7 @@ PRIVACY & ETHICS:
 
 MORE RESOURCES:
    - vignette('getting-started') - Detailed tutorial
-   - utils::help(package = 'zoomstudentengagement') - All documentation
+   - utils::help(package = 'engager') - All documentation
 ")
 }
 
@@ -98,14 +98,13 @@ show_function_help <- function(function_name) {
 
   # Show function documentation
   cat("DOCS: Documentation:\n")
-  tryCatch(
-    {
-      utils::help(function_name, package = "zoomstudentengagement")
-    },
-    error = function(e) {
-      cat("   No documentation available\n")
-    }
+  documentation <- tryCatch(
+    utils::help(function_name, package = "engager"),
+    error = function(e) NULL
   )
+  if (length(documentation) == 0) {
+    cat("   No documentation available\n")
+  }
 
   # Show usage examples for common functions
   if (function_name %in% c("basic_transcript_analysis", "quick_analysis", "batch_basic_analysis")) {
@@ -146,10 +145,10 @@ QUICK: Quick Workflow (Fastest):
 
 RESULTS: Step-by-Step Workflow (Full control):
    1. transcript <- load_zoom_transcript('file.vtt')
-   2. processed <- process_zoom_transcript(transcript)
-   3. analysis <- analyze_transcripts(processed)
-   4. plots <- plot_users(analysis)
-   5. write_metrics(analysis, 'output/')
+   2. processed <- process_zoom_transcript(transcript_df = transcript)
+   3. analysis <- summarize_transcript_metrics(transcript_df = processed)
+   4. plots <- plot_users(analysis, metric = 'wordcount', facet_by = 'transcript_file')
+   5. write_metrics(analysis, path = 'output/engagement_metrics.csv')
 
 Batch Workflow (Multiple files):
    files <- c('session1.vtt', 'session2.vtt', 'session3.vtt')
@@ -178,13 +177,13 @@ Privacy & Ethics Guidance
 ===========================
 
 Privacy Protection (Enabled by Default):
-   - Student names are automatically protected
-   - Sensitive data is anonymized
-   - privacy review helpers included
+   - Common structured identifier fields are masked by default
+   - Free transcript text still requires local review before sharing
+   - Technical privacy review helpers are included
 
 TOOLS: Privacy Functions:
    - ensure_privacy() - Apply privacy protection
-   - set_privacy_defaults() - Configure privacy settings
+   - write_metrics() - Export masked metrics without raw comments by default
    - privacy_audit() - Check privacy risks
    - review_privacy_risks() - privacy review
 
@@ -224,7 +223,7 @@ ERROR: Common Issues and Solutions:
 File Not Found:
    - Check file path is correct
    - Use list.files() to see available files
-   - Ensure file has .vtt, .txt, or .csv extension
+   - Check the function documentation for the expected file extension
 
 Permission Denied:
    - Check file permissions
@@ -238,7 +237,7 @@ Function Not Found:
 
 RESULTS: Analysis Errors:
    - Check transcript file format
-   - Use validate_schema() to check data structure
+   - Use show_function_help('load_zoom_transcript') to review input requirements
    - Try with a smaller file first
 
 Memory Issues:
@@ -250,6 +249,6 @@ TIP: Getting More Help:
    - show_getting_started() - Basic guide
    - show_function_help('function_name') - Specific help
    - find_function_for_task('task') - Find right function
-   - vignette('troubleshooting') - Detailed guide
+   - vignette('privacy-ethics-review') - Privacy review guide
 ")
 }

--- a/R/ux_interactive_help.R
+++ b/R/ux_interactive_help.R
@@ -35,9 +35,8 @@ find_function_for_task <- function(task) {
   if (grepl("load|read|import|open", task_lower)) {
     cat("Loading Transcript Files:\n")
     cat("   - load_zoom_transcript() - Load individual transcript files\n")
-    cat("   - load_transcript_files_list() - Load multiple transcript files\n")
     cat("   - load_roster() - Load student roster information\n")
-    cat("   - load_session_mapping() - Load session mapping data\n\n")
+    cat("   - summarize_transcript_files() - Load and summarize multiple transcripts\n\n")
   }
 
   # Process transcript functions
@@ -45,8 +44,8 @@ find_function_for_task <- function(task) {
     cat("Processing Transcript Data:\n")
     cat("   - process_zoom_transcript() - Clean and prepare transcript data\n")
     cat("   - consolidate_transcript() - Combine multiple transcript files\n")
-    cat("   - validate_schema() - Check data structure and format\n")
-    cat("   - join_transcripts_list() - Merge transcript with roster data\n\n")
+    cat("   - summarize_transcript_metrics() - Summarize processed transcript data\n")
+    cat("   - match_names_workflow() - Match transcript speakers to roster data\n\n")
   }
 
   # Analyze functions
@@ -54,52 +53,47 @@ find_function_for_task <- function(task) {
     cat("RESULTS: Analyzing Engagement:\n")
     cat("   - analyze_transcripts() - Calculate engagement metrics\n")
     cat("   - summarize_transcript_metrics() - Generate summary statistics\n")
-    cat("   - classify_participants() - Categorize student participation\n")
-    cat("   - calculate_content_similarity() - Analyze content patterns\n\n")
+    cat("   - analyze_multi_session_attendance() - Analyze attendance across sessions\n\n")
   }
 
   # Visualize functions
   if (grepl("visualize|plot|chart|graph|display|show", task_lower)) {
     cat("Creating Visualizations:\n")
     cat("   - plot_users() - Create engagement visualizations\n")
-    cat("   - visualize_engagement() - Generate engagement charts\n")
-    cat("   - create_engagement_report() - Generate comprehensive reports\n\n")
+    cat("   - generate_attendance_report() - Generate attendance summaries\n\n")
   }
 
   # Export functions
   if (grepl("export|save|output|write|download", task_lower)) {
     cat("Exporting Results:\n")
-    cat("   - write_metrics() - Export metrics to files (CSV, Excel, JSON)\n")
-    cat("   - write_engagement_metrics() - Export detailed engagement data\n")
-    cat("   - export_ideal_transcripts_csv() - Export to CSV format\n")
-    cat("   - export_ideal_transcripts_excel() - Export to Excel format\n\n")
+    cat("   - write_metrics() - Export privacy-processed metrics to CSV\n")
+    cat("   - write_unresolved() - Export unresolved-name review data\n")
+    cat("   - generate_privacy_review_report() - Write a privacy review report\n\n")
   }
 
   # Privacy functions
   if (grepl("privacy|protect|anonymize|mask|secure", task_lower)) {
     cat("Privacy Protection:\n")
     cat("   - ensure_privacy() - Apply privacy protection to data\n")
-    cat("   - set_privacy_defaults() - Configure privacy settings\n")
+    cat("   - write_metrics() - Export masked metrics without raw comments by default\n")
     cat("   - privacy_audit() - Check privacy risks\n")
-    cat("   - mask_user_names_by_metric() - Anonymize user names\n")
-    cat("   - review_privacy_risks() - privacy review\n\n")
+    cat("   - anonymize_educational_data() - Apply supported anonymization methods\n")
+    cat("   - review_privacy_risks() - Run a technical privacy review\n\n")
   }
 
   # Batch processing
   if (grepl("batch|multiple|several|all", task_lower)) {
     cat("Batch Processing:\n")
     cat("   - batch_basic_analysis() - Process multiple transcript files\n")
-    cat("   - process_ideal_course_batch() - Process course batches\n")
+    cat("   - summarize_transcript_files() - Summarize multiple transcripts\n")
     cat("   - analyze_multi_session_attendance() - Multi-session analysis\n\n")
   }
 
   # Validation functions
   if (grepl("validate|check|verify|test", task_lower)) {
     cat("SUCCESS: Validation & Quality:\n")
-    cat("   - validate_schema() - Check data structure\n")
-    cat("   - validate_privacy_compliance() - Check privacy risks\n")
-    cat("   - review_privacy_risks() - privacy review\n")
-    cat("   - validate_ethical_use() - Check ethical usage\n\n")
+    cat("   - validate_privacy_compliance() - Run technical identifier checks\n")
+    cat("   - review_privacy_risks() - Run a technical privacy review\n\n")
   }
 
   # If no specific matches, show general guidance
@@ -196,15 +190,14 @@ get_smart_recommendations <- function(context) {
   if (grepl("batch|multiple|several|many", context_lower)) {
     cat("Batch Processing Solutions:\n")
     cat("   1. batch_basic_analysis(files, 'output/') - Process multiple files\n")
-    cat("   2. load_transcript_files_list() - Load file lists\n")
-    cat("   3. process_ideal_course_batch() - Course-level processing\n")
-    cat("   4. analyze_multi_session_attendance() - Multi-session analysis\n\n")
+    cat("   2. summarize_transcript_files() - Summarize multiple transcripts\n")
+    cat("   3. analyze_multi_session_attendance() - Multi-session analysis\n\n")
   }
 
   if (grepl("privacy|secure|protect|anonymize|ferpa", context_lower)) {
     cat("Privacy & Security Focus:\n")
     cat("   1. ensure_privacy() - Apply privacy protection\n")
-    cat("   2. set_privacy_defaults('high') - Maximum privacy\n")
+    cat("   2. ensure_privacy(data, privacy_level = 'privacy_strict') - Broader masking\n")
     cat("   3. privacy_audit() - Check privacy risks\n")
     cat("   4. review_privacy_risks() - privacy review\n")
     cat("   5. show_privacy_guidance() - Privacy best practices\n\n")
@@ -213,16 +206,15 @@ get_smart_recommendations <- function(context) {
   if (grepl("visual|chart|graph|plot|display", context_lower)) {
     cat("Visualization Solutions:\n")
     cat("   1. plot_users() - Create engagement charts\n")
-    cat("   2. visualize_engagement() - Generate visualizations\n")
-    cat("   3. create_engagement_report() - Comprehensive reports\n\n")
+    cat("   2. generate_attendance_report() - Generate attendance summaries\n\n")
   }
 
   if (grepl("export|save|output|download|share", context_lower)) {
     cat("Export & Sharing:\n")
-    cat("   1. write_metrics() - Export to multiple formats\n")
-    cat("   2. write_engagement_metrics() - Detailed metrics\n")
-    cat("   3. export_ideal_transcripts_excel() - Excel format\n")
-    cat("   4. export_ideal_transcripts_csv() - CSV format\n\n")
+    cat("   1. write_metrics() - Export privacy-processed metrics to CSV\n")
+    cat("   2. write_unresolved() - Unresolved-name review CSV\n")
+    cat("   3. generate_attendance_report() - Attendance summary\n")
+    cat("   4. generate_privacy_review_report() - Privacy review report\n\n")
   }
 
   if (grepl("error|problem|issue|trouble|help", context_lower)) {

--- a/R/validate_privacy_compliance.R
+++ b/R/validate_privacy_compliance.R
@@ -1,10 +1,11 @@
 #' Validate Privacy Compliance
 #'
-#' Scans data objects to ensure no real names appear in outputs when privacy
-#' masking is enabled. This function performs exact matching to detect privacy
-#' violations and stops processing if real names are found.
+#' Scans data objects for possible real names when package masking is enabled.
+#' This is an exact-match technical check, not a legal or institutional
+#' compliance determination. It stops processing when configured names are
+#' found.
 #'
-#' @param data Data frame or object to validate for privacy compliance
+#' @param data Data frame or object to inspect for possible identifier exposure
 #' @param privacy_level Privacy level to validate against. One of
 #'   `c("privacy_strict", "privacy_standard", "mask", "none")`.
 #'   Defaults to `getOption("engager.privacy_level", "mask")`. Deprecated
@@ -14,7 +15,7 @@
 #' @param stop_on_violation Whether to stop processing if violations are found.
 #'   Defaults to TRUE for maximum privacy protection.
 #'
-#' @return Validation results with compliance status and any violations found
+#' @return `TRUE` when the technical check finds no configured real names.
 #' @export
 #' @examples
 #' # Validate privacy compliance

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,18 +21,18 @@ UX_COMMON_FUNCTIONS <- c(
 UX_ADVANCED_FUNCTIONS <- c(
   "consolidate_transcript",
   "summarize_transcript_metrics",
-  "detect_duplicate_transcripts",
-  "create_session_mapping",
-  "load_session_mapping",
-  "make_clean_names_df"
+  "summarize_transcript_files",
+  "detect_unmatched_names",
+  "match_names_workflow",
+  "review_privacy_risks"
 )
 
 UX_EXPERT_FUNCTIONS <- c(
-  "hash_name_consistently",
   "anonymize_educational_data",
   "validate_privacy_compliance",
-  "write_lookup_transactional",
-  "match_names_workflow"
+  "analyze_multi_session_attendance",
+  "generate_attendance_report",
+  "generate_privacy_review_report"
 )
 
 # Declare globals to silence NSE notes in CRAN checks
@@ -57,15 +57,15 @@ UX_FUNCTION_DESCRIPTIONS <- list(
   "show_function_help" = "Get help for specific function",
   "consolidate_transcript" = "Combine transcript data",
   "summarize_transcript_metrics" = "Calculate summary statistics",
-  "detect_duplicate_transcripts" = "Find duplicate content",
-  "create_session_mapping" = "Map session information",
-  "load_session_mapping" = "Load session mapping data",
-  "make_clean_names_df" = "Clean and standardize names",
-  "hash_name_consistently" = "Hash names for privacy",
+  "summarize_transcript_files" = "Summarize multiple transcript files",
+  "detect_unmatched_names" = "Find transcript speakers that need roster review",
+  "review_privacy_risks" = "Run a technical privacy review",
   "anonymize_educational_data" = "Anonymize sensitive data",
-  "validate_privacy_compliance" = "Check privacy compliance",
-  "write_lookup_transactional" = "Write lookup data safely",
-  "match_names_workflow" = "Safe name matching process"
+  "validate_privacy_compliance" = "Run technical identifier checks",
+  "match_names_workflow" = "Safe name matching process",
+  "analyze_multi_session_attendance" = "Analyze attendance across sessions",
+  "generate_attendance_report" = "Generate an attendance summary",
+  "generate_privacy_review_report" = "Generate a technical privacy review report"
 )
 
 .onAttach <- function(libname, pkgname) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,10 +30,10 @@ The goal of `engager` is to allow instructors to gain insights into student enga
 
 ## 📚 Documentation
 
-- **[docs/README.md](docs/README.md)** - Complete documentation index
-- **[docs/features/feature-index.md](docs/features/feature-index.md)** - Comprehensive feature documentation
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
-- **[docs/development/ISSUE_MANAGEMENT_QUICK_REFERENCE.md](docs/development/ISSUE_MANAGEMENT_QUICK_REFERENCE.md)** - Quick guide for issue management
+- **Installed help**: run `help(package = "engager")`
+- **Package vignettes**: run `browseVignettes(package = "engager")`
+- **[Development and contributing notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md)**
+- **[Release project status](https://github.com/revgizmo/engager/blob/main/project-docs/release/PROJECT.md)**
 
 ## 🚀 Quick Start
 
@@ -56,9 +56,9 @@ transcript_file <- system.file(
 )
 metrics <- summarize_transcript_metrics(transcript_file_path = transcript_file)
 
-# 2) Plot one metric with privacy-supporting defaults
+# 2) Plot a returned metric with privacy-supporting defaults
 #    (outputs a bar chart with a minimal theme)
-plot <- plot_users(metrics, metric = "session_ct", facet_by = "none", mask_by = "name")
+plot <- plot_users(metrics, metric = "n", facet_by = "none", mask_by = "name")
 print(plot)
 
 # 3) Write masked metrics to CSV
@@ -117,8 +117,8 @@ The `engager` package provides tools for:
 
 ### Data Management
 - `load_roster()` - Load student enrollment data
-- `make_clean_names_df()` - Match transcript names to student records
-- `create_session_mapping()` - Map recordings to courses (advanced)
+- `detect_unmatched_names()` - Identify transcript names that need review
+- `match_names_workflow()` - Apply the supported exact name-matching workflow
 
 ### Name Matching (Exact MVP)
 Use `match_names_workflow()` for exact hash-based matching:
@@ -140,9 +140,9 @@ res
 
 ### Analysis and Visualization
 - `plot_users()` - Unified plotting with privacy-aware options
-- `make_transcripts_summary_df()` - Generate summary statistics
+- `summarize_transcript_files()` - Generate metrics for multiple transcript files
 
-### Diagnostics and interactive prompts
+### Diagnostics
 
 Most functions are quiet by default to keep examples/tests clean. You can enable optional diagnostics:
 
@@ -150,20 +150,14 @@ Most functions are quiet by default to keep examples/tests clean. You can enable
 # Enable package-wide diagnostics
 options(engager.verbose = TRUE)
 
-# Or enable per-call diagnostics where supported
-load_zoom_recorded_sessions_list(
-  data_folder = ".",
-  transcripts_folder = "transcripts",
-  verbose = TRUE
-)
+# Run an exported workflow with diagnostics enabled
+summarize_transcript_metrics(transcript_file_path = transcript_file)
 
 # Turn diagnostics back off
 options(engager.verbose = FALSE)
 ```
 
-Interactive prompts (e.g., in `create_session_mapping()` when assigning unmatched recordings) are only shown in interactive sessions. In non-interactive runs (e.g., CI), prompts are suppressed and a quiet fallback is used.
-
-See also: `CONTRIBUTING.md` Diagnostic Output Policy.
+See the [development and contributing notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md) for repository-level workflow guidance.
 
 ## 📊 Typical Workflow
 
@@ -176,44 +170,48 @@ See also: `CONTRIBUTING.md` Diagnostic Output Policy.
 
 ## 🔒 Privacy Defaults
 
-This package uses privacy-supporting defaults. On load, it sets the global option
+This package uses privacy-supporting defaults. On load, it sets the session option
 `engager.privacy_level` to `"mask"` (unless you set it yourself).
-This means identifiers like names and student IDs are masked to labels such as
-`Student 01` in summaries, plots, and writers.
+Supported summaries, plots, and writers use this option to mask recognized
+structured identifier columns with labels such as `Student 01`. Masking does not
+redact names or other identifiers embedded in free transcript text, and it is
+not a legal or institutional compliance determination.
 
-To change behavior temporarily (not recommended for student data):
+To change the option temporarily for an authorized workflow, save and restore
+its prior value:
 
 ```r
 library(engager)
-set_privacy_defaults("none")  # will emit a warning
+old_privacy_level <- getOption("engager.privacy_level", "mask")
+options(engager.privacy_level = "none")
 # ... analysis that may include identifiable outputs ...
-set_privacy_defaults("mask")  # restore safe default
+options(engager.privacy_level = old_privacy_level)
 ```
 
-Masked by default: `preferred_name`, `name`, `first_last`, `name_raw`, `student_id`, `email`.
+Common structured fields considered for masking include `preferred_name`,
+`name`, `first_last`, `name_raw`, `student_id`, and `email`. Inspect all outputs
+before storing or sharing them.
 
 See `vignette("privacy-ethics-review", package = "engager")` for privacy, ethics, and institutional review considerations.
 
 ## Development
 
 ### Pull Request Review
-This project uses a lightweight PR review process focused on CRAN submission readiness and privacy risk review. See [CONTRIBUTING.md](CONTRIBUTING.md) for the review checklist and criteria.
+This project uses a lightweight PR review process focused on CRAN submission readiness and privacy risk review. See the [development and contributing notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md) for repository-level guidance.
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+We welcome contributions! Start with the [development and contributing notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md) and the [issue tracker](https://github.com/revgizmo/engager/issues).
 
 ## 📄 License
 
 This package is licensed under the MIT License. See the CRAN stub in [LICENSE](LICENSE)
-and the full text in [LICENSE.md](LICENSE.md).
+and the [full license text on GitHub](https://github.com/revgizmo/engager/blob/main/LICENSE.md).
 
 ## 🔗 Links
 
 - **GitHub Repository**: https://github.com/revgizmo/engager
 - **Issues**: https://github.com/revgizmo/engager/issues
-- **Project Status**: [docs/development/PROJECT.md](docs/development/PROJECT.md)
-
-
+- **Project Status**: [release project status](https://github.com/revgizmo/engager/blob/main/project-docs/release/PROJECT.md)
 
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
     - [Data Management](#data-management)
     - [Name Matching (Exact MVP)](#name-matching-exact-mvp)
     - [Analysis and Visualization](#analysis-and-visualization)
-    - [Diagnostics and interactive
-      prompts](#diagnostics-and-interactive-prompts)
+    - [Diagnostics](#diagnostics)
   - [📊 Typical Workflow](#bar_chart-typical-workflow)
   - [🔒 Privacy Defaults](#lock-privacy-defaults)
   - [Development](#development)
@@ -44,12 +43,12 @@ from Zoom transcripts of recorded course sessions.
 
 ## 📚 Documentation
 
-- **[docs/README.md](docs/README.md)** - Complete documentation index
-- **[docs/features/feature-index.md](docs/features/feature-index.md)** -
-  Comprehensive feature documentation
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
-- **[docs/development/ISSUE_MANAGEMENT_QUICK_REFERENCE.md](docs/development/ISSUE_MANAGEMENT_QUICK_REFERENCE.md)** -
-  Quick guide for issue management
+- **Installed help**: run `help(package = "engager")`
+- **Package vignettes**: run `browseVignettes(package = "engager")`
+- **[Development and contributing
+  notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md)**
+- **[Release project
+  status](https://github.com/revgizmo/engager/blob/main/project-docs/release/PROJECT.md)**
 
 ## 🚀 Quick Start
 
@@ -71,9 +70,9 @@ transcript_file <- system.file(
 )
 metrics <- summarize_transcript_metrics(transcript_file_path = transcript_file)
 
-# 2) Plot one metric with privacy-supporting defaults
+# 2) Plot a returned metric with privacy-supporting defaults
 #    (outputs a bar chart with a minimal theme)
-plot <- plot_users(metrics, metric = "session_ct", facet_by = "none", mask_by = "name")
+plot <- plot_users(metrics, metric = "n", facet_by = "none", mask_by = "name")
 print(plot)
 
 # 3) Write masked metrics to CSV
@@ -145,8 +144,10 @@ currently supported but may be added in future versions.
 ### Data Management
 
 - `load_roster()` - Load student enrollment data
-- `make_clean_names_df()` - Match transcript names to student records
-- `create_session_mapping()` - Map recordings to courses (advanced)
+- `detect_unmatched_names()` - Identify transcript names that need
+  review
+- `match_names_workflow()` - Apply the supported exact name-matching
+  workflow
 
 ### Name Matching (Exact MVP)
 
@@ -170,9 +171,10 @@ res
 ### Analysis and Visualization
 
 - `plot_users()` - Unified plotting with privacy-aware options
-- `make_transcripts_summary_df()` - Generate summary statistics
+- `summarize_transcript_files()` - Generate metrics for multiple
+  transcript files
 
-### Diagnostics and interactive prompts
+### Diagnostics
 
 Most functions are quiet by default to keep examples/tests clean. You
 can enable optional diagnostics:
@@ -181,23 +183,16 @@ can enable optional diagnostics:
 # Enable package-wide diagnostics
 options(engager.verbose = TRUE)
 
-# Or enable per-call diagnostics where supported
-load_zoom_recorded_sessions_list(
-  data_folder = ".",
-  transcripts_folder = "transcripts",
-  verbose = TRUE
-)
+# Run an exported workflow with diagnostics enabled
+summarize_transcript_metrics(transcript_file_path = transcript_file)
 
 # Turn diagnostics back off
 options(engager.verbose = FALSE)
 ```
 
-Interactive prompts (e.g., in `create_session_mapping()` when assigning
-unmatched recordings) are only shown in interactive sessions. In
-non-interactive runs (e.g., CI), prompts are suppressed and a quiet
-fallback is used.
-
-See also: `CONTRIBUTING.md` Diagnostic Output Policy.
+See the [development and contributing
+notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md)
+for repository-level workflow guidance.
 
 ## 📊 Typical Workflow
 
@@ -211,47 +206,56 @@ See also: `CONTRIBUTING.md` Diagnostic Output Policy.
 ## 🔒 Privacy Defaults
 
 This package uses privacy-supporting defaults. On load, it sets the
-global option `engager.privacy_level` to `"mask"` (unless you set it
-yourself). This means identifiers like names and student IDs are masked
-to labels such as `Student 01` in summaries, plots, and writers.
+session option `engager.privacy_level` to `"mask"` (unless you set it
+yourself). Supported summaries, plots, and writers use this option to
+mask recognized structured identifier columns with labels such as
+`Student 01`. Masking does not redact names or other identifiers
+embedded in free transcript text, and it is not a legal or institutional
+compliance determination.
 
-To change behavior temporarily (not recommended for student data):
+To change the option temporarily for an authorized workflow, save and
+restore its prior value:
 
 ``` r
 library(engager)
-set_privacy_defaults("none")  # will emit a warning
+old_privacy_level <- getOption("engager.privacy_level", "mask")
+options(engager.privacy_level = "none")
 # ... analysis that may include identifiable outputs ...
-set_privacy_defaults("mask")  # restore safe default
+options(engager.privacy_level = old_privacy_level)
 ```
 
-Masked by default: `preferred_name`, `name`, `first_last`, `name_raw`,
-`student_id`, `email`.
+Common structured fields considered for masking include
+`preferred_name`, `name`, `first_last`, `name_raw`, `student_id`, and
+`email`. Inspect all outputs before storing or sharing them.
 
-See `vignette("privacy-ethics-review", package = "engager")` for privacy,
-ethics, and institutional review considerations.
+See `vignette("privacy-ethics-review", package = "engager")` for
+privacy, ethics, and institutional review considerations.
 
 ## Development
 
 ### Pull Request Review
 
 This project uses a lightweight PR review process focused on CRAN
-submission readiness and privacy risk review. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for the review checklist and
-criteria.
+submission readiness and privacy risk review. See the [development and
+contributing
+notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md)
+for repository-level guidance.
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md)
-for details.
+We welcome contributions! Start with the [development and contributing
+notes](https://github.com/revgizmo/engager/blob/main/project-docs/development/README.md)
+and the [issue tracker](https://github.com/revgizmo/engager/issues).
 
 ## 📄 License
 
 This package is licensed under the MIT License. See the CRAN stub in
-[LICENSE](LICENSE) and the full text in [LICENSE.md](LICENSE.md).
+[LICENSE](LICENSE) and the [full license text on
+GitHub](https://github.com/revgizmo/engager/blob/main/LICENSE.md).
 
 ## 🔗 Links
 
 - **GitHub Repository**: <https://github.com/revgizmo/engager>
 - **Issues**: <https://github.com/revgizmo/engager/issues>
-- **Project Status**:
-  [docs/development/PROJECT.md](docs/development/PROJECT.md)
+- **Project Status**: [release project
+  status](https://github.com/revgizmo/engager/blob/main/project-docs/release/PROJECT.md)

--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -1,39 +1,58 @@
 # CRAN Comments for engager Package
 
 ## Package Information
+
 - **Package**: engager
 - **Version**: 0.1.0
-- **Note**: New package name; renamed from `zoomstudentengagement` to `engager`
+- **Submission type**: Initial CRAN submission
+- **History**: Package renamed from `zoomstudentengagement` before submission
 
 ## Test Environments
-- **Local**: macOS Tahoe 26.4.1, R 4.5.3 (2026-03-11), aarch64-apple-darwin20
-- **GitHub Actions**: Ubuntu, Windows, macOS (R release; release PR #557)
+
+- **Local**: macOS Tahoe 26.5.1, R 4.5.3 (2026-03-11), aarch64-apple-darwin20
+- **GitHub Actions baseline**: Ubuntu, Windows, and macOS with R release
 
 ## R CMD Check Results
+
 - **Errors**: 0
 - **Warnings**: 0
 - **Notes**: 0
 
+One immediately prior run produced only `unable to verify current time`; an
+unchanged rerun completed at 0 errors, 0 warnings, and 0 notes.
+
 ## Reverse Dependencies
+
 - **None** (new package)
 
 ## Additional Notes
-- Package renamed for better clarity and branding
-- Initial CRAN submission as `engager`
-- Local tests: 2,501 pass, 0 fail, 67 warnings, 6 skips
-- Local coverage: 83.82% overall; 92.34% strategic exported API coverage
-- Release PR CI: Ubuntu, Windows, and macOS R CMD check pass; coverage, lint, and build validation pass
-- Privacy-supporting defaults mask common student identifiers by default
-- Privacy-safe metric CSV exports omit raw transcript/comment text by default
-- FERPA-oriented documentation is guidance only; institutional review remains required
-- Real-world, institutionally authorized privacy validation for issue #153 was completed locally on commit `e4a78da`; the rendered sign-off approved the privacy-safe CSV export surface and did not classify raw transcripts, rosters, in-memory metric objects, or explicit raw-comment exports as de-identified
+
+- The full local test suite passes with 0 failures, 67 expected warnings, and
+  6 documented skips.
+- An installed-package UAT installs the source tarball into an isolated library
+  and exercises bundled synthetic transcript discovery, beginner and advanced
+  workflows, name matching, privacy review, CSV/report outputs, onboarding
+  guidance, and all installed vignettes.
+- The UAT uses synthetic fixtures only and writes artifacts outside the source
+  repository.
+- Privacy-supporting defaults mask recognized structured identifier fields;
+  free transcript text and contextual disclosure risks still require local
+  review.
+- Metric CSV exports omit raw transcript/comment text by default.
+- Privacy and FERPA-oriented documentation is guidance only and does not
+  certify legal or institutional compliance.
+- The release-candidate tarball contains 270 entries. Inspection found no
+  project-only release documents, development scripts, nested archives,
+  `.Rcheck` directories, local libraries, generated UAT output, or private
+  transcript/roster paths.
 
 ## Validation Status
-- [x] Local R CMD check completed
+
 - [x] Local tests passing
-- [x] Examples working under local R CMD check
-- [x] Documentation complete
-- [x] Local source build and tarball inspection complete
-- [x] Real-world privacy validation sign-off completed
-- [x] Release PR CI completed
-- [x] Ready for maintainer final review before CRAN submission
+- [x] Local `R CMD check --as-cran` completed at 0/0/0
+- [x] Examples and vignettes pass under `R CMD check`
+- [x] Source tarball builds and installs successfully
+- [x] Installed-package UAT passes
+- [x] Tarball hygiene inspection passes
+- [ ] Final remediation PR CI and review complete
+- [ ] Maintainer final release disposition recorded

--- a/man/analyze_multi_session_attendance.Rd
+++ b/man/analyze_multi_session_attendance.Rd
@@ -37,12 +37,15 @@ List containing:
 \item \code{attendance_summary}: Summary statistics for each participant
 \item \code{session_summary}: Summary statistics for each session
 \item \code{participation_patterns}: Analysis of participation patterns
-\item \code{privacy_compliant}: Boolean indicating if all outputs maintain privacy
+\item \code{privacy_compliant}: Backward-compatible Boolean indicating whether the
+package's technical privacy checks completed without an error. This is
+not a legal or institutional compliance determination.
 }
 }
 \description{
 Analyzes attendance patterns across multiple Zoom sessions, tracking who attended
-which sessions and identifying participation patterns while maintaining privacy compliance.
+which sessions and identifying participation patterns while applying the
+selected package masking controls.
 }
 \examples{
 # Analyze attendance across multiple sessions

--- a/man/basic_transcript_analysis.Rd
+++ b/man/basic_transcript_analysis.Rd
@@ -11,11 +11,13 @@ basic_transcript_analysis(
 )
 }
 \arguments{
-\item{transcript_file}{Path to transcript file (VTT, TXT, or CSV format)}
+\item{transcript_file}{Path to a WebVTT transcript file}
 
 \item{output_dir}{Output directory for results (default: "output")}
 
-\item{privacy_level}{Privacy protection level: "high" (default), "medium", "low"}
+\item{privacy_level}{Privacy protection level: "high" (default), "medium",
+or "low". These map to \code{"privacy_strict"}, \code{"privacy_standard"}, and
+\code{"mask"}, respectively. All three levels mask common identifiers.}
 }
 \value{
 List containing analysis results, plots, and output directory path

--- a/man/check_data_retention_policy.Rd
+++ b/man/check_data_retention_policy.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/privacy_review.R
 \name{check_data_retention_policy}
 \alias{check_data_retention_policy}
-\title{Check Data Retention Policy}
+\title{Review a Configured Data Retention Period}
 \usage{
 check_data_retention_policy(
   data = NULL,
@@ -13,7 +13,7 @@ check_data_retention_policy(
 )
 }
 \arguments{
-\item{data}{Data frame to check for retention policy compliance}
+\item{data}{Data frame to inspect for retention-period review}
 
 \item{retention_period}{Retention period: "academic_year", "semester", "quarter", or "custom"}
 
@@ -29,8 +29,8 @@ field is the preferred status name; \code{compliant} is retained as a
 backward-compatible alias.
 }
 \description{
-Validates data retention policies and identifies data that should be
-disposed of according to institutional policies.
+Compares configured date fields with a selected period to support local
+records review. It does not determine or enforce institutional policy.
 }
 \examples{
 \dontrun{

--- a/man/ensure_privacy.Rd
+++ b/man/ensure_privacy.Rd
@@ -24,7 +24,8 @@ ensure_privacy(
 \item{audit_log}{Whether to log privacy operations (default: TRUE)}
 }
 \value{
-Privacy-compliant version of the input object
+A privacy-processed version of the input object. This is a technical
+masking result, not a legal or institutional compliance determination.
 
 df <- tibble::tibble(
 section = c("A", "A", "B"),
@@ -46,5 +47,6 @@ compliance review remains the user's responsibility.
 
 The default behavior is controlled by the global option
 \code{engager.privacy_level}, which is set to "mask" on package
-load. Use \code{set_privacy_defaults()} to change at runtime.
+load. Pass \code{privacy_level} explicitly for one call, or set the
+\code{engager.privacy_level} option for the current R session.
 }

--- a/man/ethical_compliance.Rd
+++ b/man/ethical_compliance.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/ethical_compliance.R
 \name{ethical_compliance}
 \alias{ethical_compliance}
-\title{Ethical Compliance Functions}
+\title{Ethical Review Functions}
 \description{
-Comprehensive ethical compliance tools for educational data analysis.
-These functions ensure the package promotes participation equity rather than
-surveillance and maintains the highest ethical standards for educational research.
+Internal technical prompts for reviewing educational data-analysis use.
+These helpers do not determine whether a workflow is ethically approved or
+compliant with institutional requirements.
 }

--- a/man/validate_privacy_compliance.Rd
+++ b/man/validate_privacy_compliance.Rd
@@ -12,7 +12,7 @@ validate_privacy_compliance(
 )
 }
 \arguments{
-\item{data}{Data frame or object to validate for privacy compliance}
+\item{data}{Data frame or object to inspect for possible identifier exposure}
 
 \item{privacy_level}{Privacy level to validate against. One of
 \code{c("privacy_strict", "privacy_standard", "mask", "none")}.
@@ -26,12 +26,13 @@ common name patterns to detect potential violations.}
 Defaults to TRUE for maximum privacy protection.}
 }
 \value{
-Validation results with compliance status and any violations found
+\code{TRUE} when the technical check finds no configured real names.
 }
 \description{
-Scans data objects to ensure no real names appear in outputs when privacy
-masking is enabled. This function performs exact matching to detect privacy
-violations and stops processing if real names are found.
+Scans data objects for possible real names when package masking is enabled.
+This is an exact-match technical check, not a legal or institutional
+compliance determination. It stops processing when configured names are
+found.
 }
 \examples{
 # Validate privacy compliance

--- a/project-docs/release/CRAN_VALIDATION_REPORT.md
+++ b/project-docs/release/CRAN_VALIDATION_REPORT.md
@@ -1,53 +1,65 @@
 # CRAN Validation Report
 
-## Current Release Branch
+Generated: 2026-07-10
 
-- Branch: `codex/cran-gate-reconciliation`
-- Base: `origin/main`
-- Integrated:
-  - PR #550 branch `origin/feat/name-matching-mvp`
-  - Release-prep commit `a3954f8`
-  - CRAN gate reconciliation through commit `e4a78da`
+## Decision
+
+**GO pending remediation PR merge, hosted CI/review, and maintainer signoff.**
+
+The package-side release gates pass. CRAN upload, public tag replacement, issue
+#4 updates, and final release publication remain separately authorized owner
+actions.
+
+## Release Candidate
+
+- Branch: `codex/cran-release-surface-remediation`
+- Base: `origin/main` at `1eae39368c3d99ccfdead34cc306fb6f81c6690c`
+- Package-source commit: `1b89b7fd63044b3b7c09c67927fb28cd1bc46f6c`
+- Version: `0.1.0`
+- Tarball: `/private/tmp/engager-release-1b89b7f/engager_0.1.0.tar.gz`
+- SHA-256: `f7759c980f09ff4d152f60f19fe8110222d752061dd5df9834751582ec362a03`
+- UAT evidence: `/private/tmp/engager-release-1b89b7f/uat/UAT_EVIDENCE.md`
 
 ## Validation Matrix
 
-| Check | Status | Evidence |
+| Check | Result | Evidence |
 |---|---|---|
-| Metadata cleanup | Complete locally | `DESCRIPTION` set to `0.1.0`; `pryr` removed; PR #550 imports retained where used |
-| Release docs | Complete locally | `NEWS.md`, `cran/cran-comments.md`, and release docs added/updated |
-| Privacy wording | Complete locally | Active CRAN-facing docs reworded to privacy-supporting / FERPA-oriented language; no legal compliance guarantee claimed |
-| Issue #153 privacy validation | Approved locally | Real-world, institutionally authorized validation rendered on commit `e4a78da`: 4 outputs, no `comments` column, 0 blocking identifier scan hits, 0 metadata identifier scan hits, clean tarball check; approval limited to privacy-safe CSV export surface |
-| Issue #154 adoption guidance | Complete locally | `vignettes/privacy-ethics-review.Rmd` provides institutional adoption considerations with privacy-supporting caveats |
-| Tests | Pass locally | `devtools::test()`: 2,501 pass, 0 fail, 67 warnings, 6 skips |
-| Coverage | Pass locally | Overall 83.82%; strategic exported API 92.34% |
-| Lint | Non-blocking debt remains | `lintr::lint_package()`: 52 existing style/object-usage findings |
-| R CMD check | Pass locally | 0 errors, 0 warnings, 0 notes |
-| Build/tarball inspection | Pass locally | `R CMD build .` succeeded; tarball has 267 files and no local release docs, project-only docs, private transcript data, `.Rcheck`, `.DS_Store`, backup files, generated outputs, or excluded extdata paths |
-| Benchmarks | Complete locally | Transcript and synthetic name-matching benchmarks recorded below |
-| CI | Pass on release PR | PR #557 passes Ubuntu, Windows, and macOS R-CMD-check; coverage; lint; and build validation |
+| Live ownership | Pass | One worktree; no open PRs or `CRAN-blocker` issues before branch publication |
+| Full tests | Pass | 0 failures; 67 expected warnings; 6 documented skips |
+| R CMD check | Pass | `--no-manual --as-cran`: 0 errors, 0 warnings, 0 notes |
+| Source build | Pass | Built from package-source commit in `/private/tmp` |
+| Installed-package UAT | Pass | Isolated install; 3 sessions/34 transcript rows; beginner workflow; exact matching; privacy/report exports; 4 vignettes |
+| Onboarding/API contract | Pass | 24 progressive functions and 33 printed function calls checked against installed exports; data-format recovery path included |
+| Raw identifier scan | Pass | No bundled raw course identifier hits in checked CSV/report artifacts |
+| Tarball hygiene | Pass | 270 entries; no excluded local/project/UAT/private-data paths matched |
+| Privacy wording | Pass | Active shipped docs use technical masking/review language and preserve institutional responsibility |
+| Independent diff review | Pass | Final review returned GO with no actionable findings |
+| CRAN publication check | Not published | `engager` absent from the CRAN package index snapshot downloaded 2026-07-10 09:16 PDT |
 
-## Local Benchmark Results
+## Known Non-Blocking Evidence
 
-Run on macOS Tahoe 26.4.1, R 4.5.3, with two iterations unless noted.
+- The UAT privacy screen reports `passed = FALSE` because the in-memory metrics
+  contain identifier-like column names `name` and `name_raw`. This is expected
+  technical-screen behavior; the exported-artifact scan found no raw synthetic
+  identifier values.
+- One CRAN-check run could not verify current time and emitted that single
+  environment note. An unchanged immediate rerun completed at 0/0/0.
+- `lintr::lint_package()` reports 52 existing style/object-usage findings under
+  the repository configuration. This is pre-existing cleanup debt, not a CRAN
+  check failure or a scope justification for pre-submission refactoring.
+- Win-builder and R-hub remain optional follow-ups by release-owner decision.
+- The public `v0.1.0` tag still points to stale commit `525ea206...` and contains
+  outdated compliance wording. It was not modified. Deletion/recreation requires
+  separate explicit approval and the replacement tag should be created only for
+  the accepted release source.
 
-| Benchmark | Median Runtime | Memory |
-|---|---:|---:|
-| Small VTT parse | 35.3 ms | 8.2 MB |
-| Engagement summary | 47.8 ms | 1.3 MB |
-| Exact name matching, 100 speakers | 12.0 ms | 1.7 MB |
-| Exact name matching, 1,000 speakers | 127.7 ms | 8.8 MB |
-| Exact name matching, 5,000 speakers | 629.8 ms | 196.8 MB |
+## Remaining Gates
 
-The 5,000-speaker name-matching benchmark is sub-second locally. Memory should
-be watched in CI and future benchmark runs, but this result does not yet justify
-speculative optimization before CRAN.
-
-## Notes
-
-- Overall coverage will be reported separately from the strategic exported API
-  gate.
-- Issue #153 is approved for the CRAN privacy gate based on the rendered local
-  validation report. The approval does not classify raw transcripts, rosters,
-  in-memory metric objects, or explicitly raw comment exports as de-identified.
-- Release PR #557 was green at the time of the earlier release-prep report.
-  Recheck CI after pushing this reconciliation branch.
+1. Push the remediation branch, open the scoped PR, and require hosted checks
+   and review to pass.
+2. Merge the remediation PR and rebuild the final upload tarball from merged
+   `main`.
+3. Obtain separate approval to remove the stale public `v0.1.0` tag before
+   submission; recreate it only after CRAN acceptance.
+4. Maintainer reviews the upload packet and manually submits the tarball.
+5. Keep issue #4 open through CRAN review and acceptance.

--- a/project-docs/release/UAT_COURSE_WORKFLOW.md
+++ b/project-docs/release/UAT_COURSE_WORKFLOW.md
@@ -20,10 +20,15 @@ loads `engager` from that library, and exercises:
 
 - Installed synthetic VTT transcript discovery.
 - Installed synthetic roster discovery.
+- Installed onboarding identity plus function-call checks across getting
+  started, workflow, privacy, troubleshooting, task finder, smart
+  recommendations, error recovery, and progressive guidance output.
 - VTT loading with `load_zoom_transcript()`.
 - Transcript processing with `process_zoom_transcript()`.
 - Multi-file and single-file summarization with
   `summarize_transcript_files()` and `summarize_transcript_metrics()`.
+- The exported beginner workflow with `basic_transcript_analysis()`, including
+  its plot and privacy-processed CSV output.
 - Exact name matching with `match_names_workflow()`.
 - Unresolved-name review with `detect_unmatched_names()` and
   `write_unresolved()`.
@@ -33,7 +38,8 @@ loads `engager` from that library, and exercises:
 - Installed vignette discovery with:
   `vignette(package = "engager")`,
   `vignette("getting-started", package = "engager")`,
-  `vignette("essential-functions", package = "engager")`, and
+  `vignette("essential-functions", package = "engager")`,
+  `vignette("plotting", package = "engager")`, and
   `vignette("privacy-ethics-review", package = "engager")`.
 
 ## Prerequisites
@@ -75,7 +81,11 @@ A passing run confirms:
 - `engager` is loaded from that isolated library.
 - The installed package version matches the supplied tarball version.
 - Bundled synthetic course transcripts and roster fixtures are discoverable.
+- Installed onboarding uses the `engager` identity and progressive guidance
+  names only exported functions.
 - One or more installed VTT transcript files load and process successfully.
+- The installed beginner workflow completes with non-empty metrics, a plot,
+  and a non-empty CSV export.
 - Course-level summary metrics contain non-empty plausible data.
 - Exact name matching runs and links at least one transcript speaker to the
   synthetic roster.
@@ -92,8 +102,10 @@ Treat the UAT as failed if any of these occur:
 - The tarball cannot be installed.
 - The loaded package path is not inside the isolated UAT library.
 - Installed fixtures are missing.
-- Transcript loading, processing, summarization, name matching, privacy review,
-  privacy report generation, or exports fail.
+- Installed onboarding uses the former package identity or advertises
+  non-exported functions.
+- Transcript loading, processing, summarization, beginner workflow, name
+  matching, privacy review, privacy report generation, or exports fail.
 - Expected output files are missing or empty.
 - Exported summary/report files contain obvious raw synthetic course identifiers
   where the UAT expects masked output.

--- a/project-docs/release/run_uat_course_workflow.R
+++ b/project-docs/release/run_uat_course_workflow.R
@@ -28,6 +28,14 @@ split_aliases <- function(x) {
   trimws(pieces[nzchar(trimws(pieces))])
 }
 
+extract_function_calls <- function(lines) {
+  matches <- unlist(regmatches(
+    lines,
+    gregexpr("[A-Za-z][A-Za-z0-9_.:]*[(]", lines, perl = TRUE)
+  ))
+  sort(unique(sub("[(]$", "", matches)))
+}
+
 contains_identifiers <- function(path, identifiers) {
   identifiers <- unique(identifiers[!is.na(identifiers) & nzchar(identifiers)])
   text <- tolower(paste(readLines(path, warn = FALSE), collapse = "\n"))
@@ -131,6 +139,62 @@ check(
   paste0("installed package version matches tarball version: ", pkg_version)
 )
 
+getting_started_output <- utils::capture.output(engager::show_getting_started())
+check(
+  any(grepl("Getting Started with engager", getting_started_output, fixed = TRUE)) &&
+    !any(grepl("Getting Started with zoomstudentengagement", getting_started_output, fixed = TRUE)),
+  "installed getting-started guidance uses the engager package identity"
+)
+format_error_output <- tryCatch(
+  engager::user_friendly_error(stop("invalid transcript format"), "loading transcript"),
+  error = function(e) conditionMessage(e)
+)
+check(
+  grepl("show_function_help('load_zoom_transcript')", format_error_output, fixed = TRUE) &&
+    !grepl("validate_schema", format_error_output, fixed = TRUE),
+  "installed data-format recovery guidance names a supported public helper"
+)
+visible_functions <- engager::get_visible_functions("expert")
+namespace_exports <- getNamespaceExports("engager")
+check(
+  length(setdiff(visible_functions, namespace_exports)) == 0,
+  "installed progressive guidance lists only exported functions"
+)
+guidance_output <- c(
+  getting_started_output,
+  format_error_output,
+  utils::capture.output(engager::show_workflow_help()),
+  utils::capture.output(engager::show_privacy_guidance()),
+  utils::capture.output(engager::show_troubleshooting()),
+  unlist(lapply(
+    c("load", "process", "analyze", "visualize", "export", "privacy", "batch", "validate"),
+    function(task) utils::capture.output(engager::find_function_for_task(task))
+  )),
+  unlist(lapply(
+    c("new user", "batch", "privacy", "visual", "export", "error"),
+    function(context) utils::capture.output(engager::get_smart_recommendations(context))
+  )),
+  utils::capture.output(engager::show_available_functions("expert")),
+  utils::capture.output(engager::show_function_categories())
+)
+guidance_calls <- extract_function_calls(guidance_output)
+allowed_external_calls <- c("c", "list.files", "utils::help", "vignette")
+unexpected_guidance_calls <- setdiff(
+  guidance_calls,
+  c(namespace_exports, allowed_external_calls)
+)
+check(
+  length(unexpected_guidance_calls) == 0,
+  paste0(
+    "installed onboarding recommends only exported package functions",
+    if (length(unexpected_guidance_calls) > 0) {
+      paste0(": ", paste(unexpected_guidance_calls, collapse = ", "))
+    } else {
+      ""
+    }
+  )
+)
+
 test_transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
 check(dir.exists(test_transcript_dir), "discovered installed synthetic transcript fixture directory")
 
@@ -195,6 +259,27 @@ single_session_metrics <- engager::summarize_transcript_metrics(
 check(
   tibble::is_tibble(single_session_metrics) && nrow(single_session_metrics) > 0,
   "summarized a single transcript session"
+)
+
+basic_workflow_dir <- file.path(artifact_dir, "basic_workflow")
+basic_workflow <- engager::basic_transcript_analysis(
+  ideal_files[[1]],
+  output_dir = basic_workflow_dir,
+  privacy_level = "high"
+)
+basic_workflow_path <- file.path(basic_workflow_dir, "engagement_metrics.csv")
+check(
+  is.list(basic_workflow) &&
+    tibble::is_tibble(basic_workflow$analysis) &&
+    nrow(basic_workflow$analysis) > 0,
+  "ran installed beginner workflow with non-empty engagement metrics"
+)
+check(inherits(basic_workflow$plots, "ggplot"), "created installed beginner workflow plot")
+check(non_empty_file(basic_workflow_path), "wrote installed beginner workflow CSV")
+basic_workflow_export <- utils::read.csv(basic_workflow_path, check.names = FALSE)
+check(
+  nrow(basic_workflow_export) > 0 && !"comments" %in% names(basic_workflow_export),
+  "installed beginner workflow CSV contains rows and omits raw comments"
 )
 
 roster <- engager::load_roster(roster_path)
@@ -288,7 +373,13 @@ identifier_values <- unique(c(
   "Professor Ed"
 ))
 identifier_values <- identifier_values[nchar(identifier_values) >= 4]
-privacy_checked_paths <- c(engagement_path, session_summary_path, single_session_path, privacy_report_path)
+privacy_checked_paths <- c(
+  engagement_path,
+  session_summary_path,
+  single_session_path,
+  basic_workflow_path,
+  privacy_report_path
+)
 identifier_hits <- unlist(lapply(privacy_checked_paths, contains_identifiers, identifiers = identifier_values))
 check(
   length(identifier_hits) == 0,
@@ -298,7 +389,7 @@ check(
 all_vignettes <- utils::vignette(package = "engager")
 check(!is.null(all_vignettes$results) && NROW(all_vignettes$results) > 0, "listed installed package vignettes")
 
-required_vignettes <- c("getting-started", "essential-functions", "privacy-ethics-review")
+required_vignettes <- c("getting-started", "essential-functions", "plotting", "privacy-ethics-review")
 for (required_vignette in required_vignettes) {
   vignette_result <- utils::vignette(required_vignette, package = "engager")
   vignette_info <- unclass(vignette_result)
@@ -320,12 +411,15 @@ evidence_lines <- c(
   paste0("- Tarball package version: ", expected_pkg_version),
   paste0("- Tarball: ", tarball),
   paste0("- Installed package path: ", installed_path),
+  paste0("- Expert guidance functions checked: ", length(visible_functions)),
+  paste0("- Onboarding function calls checked: ", length(guidance_calls)),
   paste0("- R version: ", R.version.string),
   paste0("- Platform: ", R.version$platform),
   paste0("- Output directory: ", output_dir),
   paste0("- Transcript sessions loaded: ", length(ideal_files)),
   paste0("- Transcript rows loaded: ", nrow(transcripts_for_matching)),
   paste0("- Summary metric rows: ", nrow(metrics)),
+  paste0("- Beginner workflow metric rows: ", nrow(basic_workflow$analysis)),
   paste0("- Matched transcript rows: ", sum(!is.na(match_result$transcripts_with_ids$student_id))),
   paste0("- Unresolved speaker groups: ", nrow(unresolved_public)),
   paste0("- Privacy review passed field: ", privacy_review$passed),
@@ -336,6 +430,7 @@ evidence_lines <- c(
   paste0("- ", engagement_path),
   paste0("- ", session_summary_path),
   paste0("- ", single_session_path),
+  paste0("- ", basic_workflow_path),
   paste0("- ", unresolved_path),
   paste0("- ", privacy_report_path),
   paste0("- ", install_log)

--- a/tests/testthat/test-basic_transcript_analysis.R
+++ b/tests/testthat/test-basic_transcript_analysis.R
@@ -8,6 +8,7 @@ test_that("basic_transcript_analysis errors when file missing", {
 })
 
 test_that("basic_transcript_analysis creates output dir and returns structured result", {
+  withr::local_options(engager.privacy_level = "mask")
   # Prepare a temp file path and output dir
   tf <- tempfile(fileext = ".vtt")
   writeLines(c("WEBVTT", "\n", "00:00:00.000 --> 00:00:01.000", "Hello"), tf)
@@ -31,21 +32,30 @@ test_that("basic_transcript_analysis creates output dir and returns structured r
       expect_true(file.exists(path))
       fake_transcript
     },
-    process_zoom_transcript = function(df, ...) {
-      expect_true(is.data.frame(df))
+    process_zoom_transcript = function(transcript_file_path = "", transcript_df = NULL, ...) {
+      expect_equal(transcript_file_path, "")
+      expect_true(is.data.frame(transcript_df))
       fake_processed
     },
-    analyze_transcripts = function(df, ...) {
-      expect_true(is.data.frame(df))
+    summarize_transcript_metrics = function(transcript_file_path = "", transcript_df = NULL, ...) {
+      expect_equal(transcript_file_path, "")
+      expect_true(is.data.frame(transcript_df))
       fake_analysis
     },
-    plot_users = function(analysis, ...) {
+    plot_users = function(analysis, metric, student_col, facet_by, privacy_level, ...) {
       expect_true(is.data.frame(analysis))
+      expect_equal(metric, "wordcount")
+      expect_equal(student_col, "name")
+      expect_equal(facet_by, "none")
+      expect_equal(privacy_level, "none")
       fake_plots
     },
-    write_metrics = function(analysis, path, ...) {
+    write_metrics = function(analysis, what, path, privacy_level, comments_policy, ...) {
       expect_true(is.data.frame(analysis))
-      expect_true(dir.exists(path))
+      expect_equal(what, "engagement")
+      expect_equal(path, file.path(outdir, "engagement_metrics.csv"))
+      expect_equal(privacy_level, "privacy_strict")
+      expect_equal(comments_policy, "omit")
       invisible(NULL)
     },
     {
@@ -56,8 +66,77 @@ test_that("basic_transcript_analysis creates output dir and returns structured r
       expect_equal(res$output_dir, outdir)
       expect_equal(res$transcript_file, tf)
       expect_equal(res$privacy_level, "high")
+      expect_equal(getOption("engager.privacy_level"), "mask")
     }
   )
+})
+
+test_that("basic_transcript_analysis runs the installed synthetic workflow", {
+  withr::local_options(engager.privacy_level = "mask")
+  transcript_file <- system.file(
+    "extdata/test_transcripts/ideal_course_session1.vtt",
+    package = "engager"
+  )
+  expect_true(nzchar(transcript_file))
+  output_dir <- withr::local_tempdir()
+  raw_names <- unique(load_zoom_transcript(transcript_file)$name)
+
+  result <- basic_transcript_analysis(transcript_file, output_dir, privacy_level = "high")
+
+  expect_s3_class(result$analysis, "tbl_df")
+  expect_gt(nrow(result$analysis), 0)
+  expect_s3_class(result$plots, "ggplot")
+  output_path <- file.path(output_dir, "engagement_metrics.csv")
+  expect_true(file.exists(output_path))
+  exported <- utils::read.csv(output_path, check.names = FALSE)
+  expect_gt(nrow(exported), 0)
+  expect_false("comments" %in% names(exported))
+  export_text <- tolower(paste(unlist(exported), collapse = "\n"))
+  identifier_hits <- raw_names[vapply(
+    raw_names,
+    function(name) grepl(tolower(name), export_text, fixed = TRUE),
+    logical(1)
+  )]
+  expect_length(identifier_hits, 0)
+  expect_equal(result$plots$data$name, result$analysis$name)
+  expect_equal(getOption("engager.privacy_level"), "mask")
+})
+
+test_that("basic workflow keeps medium and low exports masked", {
+  withr::local_options(engager.privacy_level = "mask")
+  transcript_file <- system.file(
+    "extdata/test_transcripts/ideal_course_session1.vtt",
+    package = "engager"
+  )
+  raw_names <- unique(load_zoom_transcript(transcript_file)$name)
+  output_root <- withr::local_tempdir()
+
+  for (level in c("medium", "low")) {
+    result <- basic_transcript_analysis(
+      transcript_file,
+      file.path(output_root, level),
+      privacy_level = level
+    )
+    output_path <- file.path(output_root, level, "engagement_metrics.csv")
+    exported <- utils::read.csv(output_path, check.names = FALSE)
+    export_text <- tolower(paste(unlist(exported), collapse = "\n"))
+    identifier_hits <- raw_names[vapply(
+      raw_names,
+      function(name) grepl(tolower(name), export_text, fixed = TRUE),
+      logical(1)
+    )]
+    expect_length(identifier_hits, 0)
+    expect_equal(result$plots$data$name, result$analysis$name)
+    expect_equal(getOption("engager.privacy_level"), "mask")
+  }
+})
+
+test_that("basic privacy levels map to supported masking levels", {
+  expect_equal(normalize_basic_privacy_level("high"), "privacy_strict")
+  expect_equal(normalize_basic_privacy_level("medium"), "privacy_standard")
+  expect_equal(normalize_basic_privacy_level("low"), "mask")
+  expect_error(normalize_basic_privacy_level("none"), "must be one of")
+  expect_error(normalize_basic_privacy_level(c("high", "low")), "must be one of")
 })
 
 test_that("quick_analysis delegates to basic_transcript_analysis", {
@@ -84,6 +163,22 @@ test_that("quick_analysis delegates to basic_transcript_analysis", {
   )
 })
 
+test_that("quick_analysis runs a bundled transcript without source-tree assumptions", {
+  withr::local_options(engager.privacy_level = "mask")
+  work_dir <- withr::local_tempdir()
+  withr::local_dir(work_dir)
+  transcript_file <- system.file(
+    "extdata/test_transcripts/ideal_course_session1.vtt",
+    package = "engager"
+  )
+
+  result <- quick_analysis(transcript_file)
+
+  expect_s3_class(result$analysis, "tbl_df")
+  expect_true(file.exists(file.path(work_dir, "quick_output", "engagement_metrics.csv")))
+  expect_equal(getOption("engager.privacy_level"), "mask")
+})
+
 test_that("batch_basic_analysis validates and processes multiple files", {
   files <- c(tempfile(fileext = ".vtt"), tempfile(fileext = ".vtt"))
   lapply(files, function(f) writeLines(c("WEBVTT", "\n", "00:00:00.000 --> 00:00:01.000", "Hello"), f))
@@ -105,4 +200,22 @@ test_that("batch_basic_analysis validates and processes multiple files", {
       expect_true(dir.exists(file.path(outdir, "session_2")))
     }
   )
+})
+
+test_that("batch_basic_analysis runs bundled transcripts into isolated session directories", {
+  withr::local_options(engager.privacy_level = "mask")
+  transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
+  files <- file.path(
+    transcript_dir,
+    c("ideal_course_session1.vtt", "ideal_course_session2.vtt")
+  )
+  output_dir <- withr::local_tempdir()
+
+  results <- batch_basic_analysis(files, output_dir, privacy_level = "medium")
+
+  expect_length(results, 2)
+  expect_true(all(vapply(results, function(x) is.null(x$error), logical(1))))
+  expect_true(file.exists(file.path(output_dir, "session_1", "engagement_metrics.csv")))
+  expect_true(file.exists(file.path(output_dir, "session_2", "engagement_metrics.csv")))
+  expect_equal(getOption("engager.privacy_level"), "mask")
 })

--- a/tests/testthat/test-ux_guidance_system-coverage.R
+++ b/tests/testthat/test-ux_guidance_system-coverage.R
@@ -28,6 +28,45 @@ test_that("show_troubleshooting provides actionable suggestions", {
   expect_true(any(grepl("Getting More Help", output, fixed = TRUE)))
 })
 
+test_that("exported onboarding recommends only callable public functions", {
+  format_error_output <- tryCatch(
+    user_friendly_error(stop("invalid transcript format"), "loading transcript"),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(format_error_output, "show_function_help\\('load_zoom_transcript'\\)")
+  expect_false(grepl("validate_schema", format_error_output, fixed = TRUE))
+
+  outputs <- c(
+    capture.output(show_getting_started()),
+    format_error_output,
+    capture.output(show_workflow_help()),
+    capture.output(show_privacy_guidance()),
+    capture.output(show_troubleshooting()),
+    unlist(lapply(
+      c("load", "process", "analyze", "visualize", "export", "privacy", "batch", "validate"),
+      function(task) capture.output(find_function_for_task(task))
+    )),
+    unlist(lapply(
+      c("new user", "batch", "privacy", "visual", "export", "error"),
+      function(context) capture.output(get_smart_recommendations(context))
+    )),
+    capture.output(show_available_functions("expert")),
+    capture.output(show_function_categories())
+  )
+  matches <- unlist(regmatches(
+    outputs,
+    gregexpr("[A-Za-z][A-Za-z0-9_.:]*[(]", outputs, perl = TRUE)
+  ))
+  calls <- sort(unique(sub("[(]$", "", matches)))
+  allowed_external_calls <- c("c", "list.files", "utils::help", "vignette")
+  unexpected_calls <- setdiff(
+    calls,
+    c(getNamespaceExports("engager"), allowed_external_calls)
+  )
+
+  expect_length(unexpected_calls, 0)
+})
+
 test_that("show_function_help handles unknown functions gracefully", {
   dummy_ns <- new.env(parent = emptyenv())
   # Mock the engager namespace lookup so we can exercise
@@ -58,7 +97,8 @@ test_that("show_function_help categorizes essential functions", {
   )
   expect_true(any(grepl("Essential Function", output, fixed = TRUE)))
   expect_true(any(grepl("TIP: Usage Examples", output, fixed = TRUE)))
-  expect_true(any(grepl("No documentation available", output, fixed = TRUE)))
+  expect_true(any(grepl("DOCS: Documentation", output, fixed = TRUE)))
+  expect_false(any(grepl("No documentation available", output, fixed = TRUE)))
 })
 
 test_that("show_function_help falls back to generic labeling when uncategorized", {

--- a/vignettes/essential-functions.Rmd
+++ b/vignettes/essential-functions.Rmd
@@ -20,12 +20,12 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-This vignette demonstrates the core functionality of the `engager` package using only the essential functions. After scope reduction, the package now exports **26 essential functions** focused on:
+This vignette demonstrates the core functionality of the `engager` package using its public API. The package currently exports **37 functions** focused on:
 
 - **Transcript Processing**: Loading and processing Zoom transcripts
-- **Privacy Protection**: Applying privacy-supporting defaults and privacy review
+- **Privacy-Supporting Workflows**: Applying structured-field masking and technical review
 - **Analysis**: Core engagement metrics and analysis
-- **Name Matching**: Safe student name matching workflows
+- **Name Matching**: Reviewable exact student name matching workflows
 
 ## Essential Functions
 
@@ -47,11 +47,37 @@ if (length(essential_functions) == 0) {
     "summarize_transcript_files",
     "analyze_transcripts",
     "summarize_transcript_metrics",
+    "analyze_multi_session_attendance",
+    "anonymize_educational_data",
+    "basic_transcript_analysis",
+    "batch_basic_analysis",
+    "detect_unmatched_names",
     "ensure_privacy",
+    "find_function_for_task",
+    "generate_attendance_report",
+    "generate_privacy_review_report",
+    "get_smart_recommendations",
+    "get_ux_level",
+    "get_visible_functions",
+    "load_roster",
+    "match_names_workflow",
     "privacy_audit",
+    "quick_analysis",
+    "review_privacy_risks",
+    "set_ux_level",
+    "show_available_functions",
+    "show_error_recovery",
+    "show_function_categories",
+    "show_function_help",
+    "show_getting_started",
+    "show_privacy_guidance",
+    "show_troubleshooting",
+    "show_workflow_help",
+    "user_friendly_error",
     "validate_privacy_compliance",
     "plot_users",
-    "write_metrics"
+    "write_metrics",
+    "write_unresolved"
   )
 }
 
@@ -115,9 +141,10 @@ synthetic_data <- data.frame(
   timestamp = c("00:01:00", "00:02:00", "00:00:30")
 )
 
-# Note: Privacy review functions check for real names in data
-cat("Privacy review functions check whether real names are exposed\n")
-cat("validate_privacy_compliance() and review_privacy_risks() support privacy review\n")
+# Privacy review helpers flag recognized identifier-like columns. They do not
+# prove that a data set or free-text field contains no identifying information.
+cat("Privacy review helpers flag recognized identifier-like columns\n")
+cat("validate_privacy_compliance() and review_privacy_risks() support technical review\n")
 ```
 
 ## Function Categories
@@ -133,7 +160,7 @@ cat("validate_privacy_compliance() and review_privacy_risks() support privacy re
 - `summarize_transcript_metrics()` - Calculate engagement metrics
 
 ### Privacy Review
-- `ensure_privacy()` - Apply privacy protection
+- `ensure_privacy()` - Mask recognized structured identifier columns
 - `privacy_audit()` - Audit privacy risks
 - `validate_privacy_compliance()` - Review privacy settings
 
@@ -146,19 +173,22 @@ cat("validate_privacy_compliance() and review_privacy_risks() support privacy re
 
 ## Benefits of Scope Reduction
 
-1. **Focused Functionality**: Only essential functions are exported
+1. **Focused Functionality**: Public functions are organized around the supported workflows
 2. **Easier Maintenance**: Smaller codebase to maintain
 3. **Better User Experience**: Clear, focused API
-4. **CRAN Ready**: Minimal function surface for submission
-5. **Privacy Supporting**: All functions prioritize data protection
+4. **CRAN Focused**: A bounded public surface for release validation
+5. **Privacy Supporting**: Output helpers provide documented masking and review controls
 
 ## Next Steps
 
-With the scope reduction complete, the package is now ready for:
+With the scope reduction complete, the package supports:
 
-1. **CRAN Submission**: Minimal, focused function set
+1. **CRAN Validation**: A focused function set to validate before submission
 2. **User Testing**: Clear, essential functionality
 3. **Documentation Updates**: Focus on core workflows
 4. **UX Simplification**: Streamlined user experience
 
-The package now provides a clean, focused API for analyzing student engagement from Zoom transcripts while maintaining strong privacy-supporting defaults and privacy review helpers.
+The package now provides a focused API for analyzing student engagement from
+Zoom transcripts with documented structured-field masking and technical review
+helpers. Users remain responsible for reviewing inputs, free text, outputs, and
+institutional requirements.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -60,14 +60,14 @@ summary_metrics <- summarize_transcript_metrics(
   names_exclude = c("dead_air")
 )
 
-# View the results (privacy-safe by default)
+# View the results (recognized structured identifiers are masked by default)
 head(summary_metrics)
 
-# Run a privacy audit
+# Run a technical privacy review
 privacy_result <- privacy_audit(summary_metrics)
 cat(
-  "Privacy Check:",
-  ifelse(nrow(privacy_result) == 0, "No issues found", "Issues found"),
+  "Privacy review:",
+  ifelse(nrow(privacy_result) == 0, "No recognized issues flagged", "Review flags returned"),
   "\n"
 )
 ```
@@ -80,8 +80,8 @@ The `engager` package provides tools for:
 3. **Name Matching and Cleaning**: Match transcript names to student rosters
 4. **Visualization**: Create plots to analyze participation patterns
 5. **Reporting**: Generate individual student reports
-6. **Privacy Review**: Support privacy review and institutional oversight
-7. **Data Anonymization**: Protect student privacy while preserving data utility
+6. **Privacy Review**: Support technical review and institutional oversight
+7. **Masking and Data Transformation**: Reduce exposure of recognized structured identifiers
 
 ## Basic Workflow
 
@@ -92,12 +92,14 @@ The typical workflow involves:
 3. **Load Roster**: Import student enrollment data
 4. **Clean Names**: Match transcript names to student records
 5. **Analyze**: Calculate metrics and create visualizations
-6. **Review Privacy**: Audit outputs and anonymize data where needed
+6. **Review Privacy**: Review outputs and apply masking or other transformations where needed
 7. **Report**: Generate insights and reports
 
 ## Troubleshooting Name Matching Issues
 
-When working with Zoom transcripts and student rosters, you may encounter name matching issues. The package uses a privacy-supporting approach that stops processing when names cannot be safely matched.
+When working with Zoom transcripts and student rosters, you may encounter name
+matching issues. The supported `match_names_workflow()` uses exact matching and
+reports unresolved names rather than silently guessing a match.
 
 ### Common Issues and Solutions
 

--- a/vignettes/plotting.Rmd
+++ b/vignettes/plotting.Rmd
@@ -169,9 +169,11 @@ students_only_summary <- transcripts_summary_df %>%
 plot_users(students_only_summary, metric = "session_ct", facet_by = "section", mask_by = "name")
 ```
 
-### Masked Names for Privacy
+### Masked Labels for Review
 
-Use rank-based masked labels for privacy-conscious analysis:
+Use rank-based masked labels as one privacy-supporting step. Inspect the source
+data and finished plot because masking one label column does not review free
+text, annotations, small groups, or other identifying context:
 
 ```{r masked-plots}
 # Plot with rank-masked names
@@ -285,7 +287,7 @@ ggplot(transcripts_summary_df, aes(x = duration, y = wordcount)) +
 
 ### Privacy Considerations
 
-- Use masked names when sharing results
+- Inspect outputs and apply masking appropriate to the approved sharing context
 - Consider aggregating data for small groups
 - Review FERPA and institutional privacy requirements before sharing outputs
 
@@ -298,6 +300,6 @@ ggplot(transcripts_summary_df, aes(x = duration, y = wordcount)) +
 
 ## Next Steps
 
-- **For session mapping**: See the [Session Mapping](session-mapping.html) vignette
-- **For student reports**: See the [Student Reports](student-reports.html) vignette
-- **For troubleshooting**: See the [Troubleshooting Guide](troubleshooting.html) vignette 
+- **For the end-to-end workflow**: see `vignette("getting-started", package = "engager")`
+- **For exported function coverage**: see `vignette("essential-functions", package = "engager")`
+- **For privacy, ethics, and institutional review**: see `vignette("privacy-ethics-review", package = "engager")`

--- a/vignettes/privacy-ethics-review.Rmd
+++ b/vignettes/privacy-ethics-review.Rmd
@@ -62,7 +62,7 @@ review:
 The broadest built-in masking option:
 
 ```r
-set_privacy_defaults("privacy_strict")
+options(engager.privacy_level = "privacy_strict")
 ```
 
 This level masks:
@@ -79,7 +79,7 @@ This level masks:
 A broader masking option for many instructional workflows:
 
 ```r
-set_privacy_defaults("privacy_standard")
+options(engager.privacy_level = "privacy_standard")
 ```
 
 This level masks:
@@ -92,7 +92,7 @@ This level masks:
 The package default for basic identifier masking:
 
 ```r
-set_privacy_defaults("mask")
+options(engager.privacy_level = "mask")
 ```
 
 This level masks:
@@ -104,8 +104,12 @@ Turns off package masking. This is usually not appropriate for student data
 unless local review has authorized identifiable outputs:
 
 ```r
-set_privacy_defaults("none")  # Will emit a warning
+options(engager.privacy_level = "none")
 ```
+
+Setting the option does not modify existing objects. Supported masking and
+output helpers may warn when they run with this value; inspect their results
+before storing or sharing them.
 
 ## Privacy Review Functions
 
@@ -132,21 +136,24 @@ print(validation_result$passed)
 print(validation_result$recommendations)
 ```
 
-### Data Anonymization
+### Data Masking and Transformation
 
-You can anonymize data using several package methods:
+`anonymize_educational_data()` applies masking, hashing, pseudonymization, or
+aggregation transformations to recognized columns. These technical operations
+do not by themselves establish that re-identification is impossible or that an
+output satisfies a legal or institutional definition of anonymized data.
 
 ```r
-# Basic masking
+# Structured-field masking
 masked_data <- anonymize_educational_data(sample_data, method = "mask")
 
-# Hash-based anonymization
+# Hashing transform
 hashed_data <- anonymize_educational_data(sample_data, method = "hash", hash_salt = "institution_salt")
 
-# Pseudonymization
+# Pseudonymization transform
 pseudonymized_data <- anonymize_educational_data(sample_data, method = "pseudonymize")
 
-# Aggregation-based anonymization
+# Aggregation transform
 aggregated_data <- anonymize_educational_data(sample_data, method = "aggregate", aggregation_level = "section")
 ```
 
@@ -176,25 +183,30 @@ written_report <- engager::generate_privacy_review_report(
 unlink(report_file)
 ```
 
-### Data Retention
+### Data Retention Review
 
-You can check a data frame against a retention period:
+The exported review interface can record a retention period as part of a
+technical review. It does not enforce an institutional records schedule or
+decide which records may be retained or disposed of:
 
 ```r
 # Add date column for retention checking
 sample_data_with_dates <- sample_data %>%
   dplyr::mutate(session_date = as.Date(c("2024-01-15", "2024-02-20")))
 
-# Check retention policy
-retention_check <- check_data_retention_policy(
+# Include retention context in the technical review
+retention_review <- review_privacy_risks(
   sample_data_with_dates,
-  retention_period = "academic_year",
-  date_column = "session_date"
+  check_retention = TRUE,
+  retention_period = "academic_year"
 )
 
-print(retention_check$compliant)
-print(retention_check$recommendations)
+print(retention_review$retention_check$retention_period_days)
+print(retention_review$recommendations)
 ```
+
+Compare record dates with the institution-approved schedule in the authorized
+records-management system, and have the appropriate owner approve any disposal.
 
 ## Institutional Review Considerations
 
@@ -244,7 +256,7 @@ print(combined_review$institution_guidance)
 
 Consider classifying the data before analysis:
 
-- **Public Data**: Aggregated statistics, anonymized results
+- **Public Data**: Results approved for public release after aggregation or de-identification review
 - **Internal Data**: Student records for legitimate educational purposes
 - **Confidential Data**: Personally identifiable information requiring special protection
 
@@ -272,7 +284,7 @@ Follow local retention and disposal procedures:
 
 - Implement automated data disposal
 - Document disposal procedures
-- Verify complete data removal
+- Verify removal according to the approved local procedure
 - Maintain disposal audit trails
 
 ## Instructor Review Prompts
@@ -326,7 +338,7 @@ This checklist may help support institutional privacy review:
 - [ ] Document procedures
 
 ### Ongoing
-- [ ] Regular privacy audits
+- [ ] Regular technical privacy reviews
 - [ ] Staff training updates
 - [ ] Policy reviews
 - [ ] Security assessments
@@ -372,7 +384,7 @@ level:
 ```r
 library(engager)
 
-set_privacy_defaults("mask")
+options(engager.privacy_level = "mask")
 getOption("engager.privacy_level")
 ```
 
@@ -439,8 +451,8 @@ If privacy masking isn't working as expected:
 # Check current privacy level
 getOption("engager.privacy_level")
 
-# Reset to default
-set_privacy_defaults("mask")
+# Reset the documented session option
+options(engager.privacy_level = "mask")
 
 # Verify with sample data
 test_data <- tibble::tibble(name = "Test Student")
@@ -456,27 +468,27 @@ If privacy validation is flagging issues:
 validation_result <- review_privacy_risks(your_data)
 print(validation_result$pii_detected)
 
-# Anonymize the data
-anonymized_data <- anonymize_educational_data(your_data, method = "mask")
+# Mask recognized structured identifier columns
+masked_data <- anonymize_educational_data(your_data, method = "mask")
 
 # Re-validate
-review_privacy_risks(anonymized_data)
+review_privacy_risks(masked_data)
 ```
 
-### Data Retention Issues
+### Data Retention Questions
 
-If data retention checks are flagging issues:
+If the technical review raises retention questions:
 
 ```r
-# Check retention policy
-retention_check <- check_data_retention_policy(
+# Record the retention context in the exported review interface
+retention_review <- review_privacy_risks(
   your_data,
-  retention_period = "academic_year",
-  date_column = "your_date_column"
+  check_retention = TRUE,
+  retention_period = "academic_year"
 )
 
-# Review recommendations
-print(retention_check$recommendations)
+# Review technical prompts, then apply the institution-approved schedule
+print(retention_review$recommendations)
 ```
 
 ## Ethical Use Principles
@@ -533,7 +545,7 @@ Center student benefit in data use:
 
 ### Package Resources
 - Package documentation: `?engager`
-- Privacy functions: `?ensure_privacy`, `?set_privacy_defaults`
+- Privacy masking: `?ensure_privacy` and `getOption("engager.privacy_level")`
 - Privacy review functions: `?review_privacy_risks`, `?anonymize_educational_data`
 - Report generation: `?generate_privacy_review_report`
 


### PR DESCRIPTION
## Summary
- repair the exported basic, quick, and batch transcript workflows against their real downstream contracts
- map beginner privacy levels to supported masking modes and restore caller options
- remove internal/nonexistent API recommendations and stale package identity from shipped guidance
- soften privacy/compliance wording to technical masking and institutional-review language
- expand real-fixture tests and installed-tarball UAT coverage for workflow composition and onboarding exports
- refresh CRAN validation and maintainer evidence

## Validation
- `devtools::test(reporter = "summary")`: PASS, 0 failures; 67 expected warnings; 6 skips
- `devtools::check(args = c("--no-manual", "--as-cran"), error_on = "never")`: 0 errors, 0 warnings, 0 notes
- `R CMD build`: PASS from `/private/tmp`
- installed-package UAT: PASS from isolated library
- tarball hygiene: PASS, 270 entries
- candidate SHA-256: `f7759c980f09ff4d152f60f19fe8110222d752061dd5df9834751582ec362a03`
- independent final diff review: GO, no actionable findings
- `git diff --check`: PASS

## Release boundaries
- no real/private course data used
- no public tag, release, issue, or CRAN mutation performed
- win-builder and R-hub remain optional
- issue #4 stays open through CRAN acceptance
- stale public `v0.1.0` tag remains untouched pending separate approval

## Post-merge gate
Rebuild and revalidate the final upload tarball from merged `main`, obtain maintainer signoff, then handle stale-tag deletion and manual CRAN submission only under their separate approvals.