### PR TITLE
fix: restore internal pkgdown topic

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -97,6 +97,7 @@ reference:
   - starts_with("engager-")
   - hash_canonical_name
   - starts_with("lookup_")
+  - make_blank_cancelled_classes_df
   - match_names_exact
   - match_names_fuzzy
   - normalize_name


### PR DESCRIPTION
## Summary

- restore `make_blank_cancelled_classes_df` to the pkgdown reference index
- keep it categorized as an internal function
- fix the merged-main Pages failure without changing the package API or tarball payload

## Evidence

- isolated full `pkgdown::build_site()` completed successfully
- reference metadata reports OK
- merged-main tests passed with zero failures
- merged-main `R CMD check --as-cran` passed at 0 errors, 0 warnings, 0 notes
- final merged-main tarball UAT passed before this docs-only, tarball-excluded change

## Boundaries

No R code, exports, package documentation, tests, fixtures, release tags, issues, or CRAN state are changed.