### PR TITLE
docs: record final CRAN validation evidence

### DIFF
--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -10,6 +10,8 @@
 
 - **Local**: macOS Tahoe 26.5.1, R 4.5.3 (2026-03-11), aarch64-apple-darwin20
 - **GitHub Actions baseline**: Ubuntu, Windows, and macOS with R release
+- **R-devel win-builder**: Windows Server 2022 x64, R Under development
+  (2026-07-10 r90234 ucrt)
 
 ## R CMD Check Results
 
@@ -17,9 +19,11 @@
 - **Warnings**: 0
 - **Notes**: 1
 
-The note is the expected informational `New submission` note. A canonical local
-check with incoming feasibility disabled completed with 0 errors, 0 warnings, and
-0 notes.
+The R-devel win-builder note is the expected informational `New submission`
+note. Its incoming-feasibility output also identifies `WebVTT` (the transcript
+format name) and `reviewable` (an intentional English word) as possible
+misspellings. A canonical local check with incoming feasibility disabled
+completed with 0 errors, 0 warnings, and 0 notes.
 
 ## Reverse Dependencies
 
@@ -51,6 +55,16 @@ check with incoming feasibility disabled completed with 0 errors, 0 warnings, an
   project-only release documents, development scripts, nested archives,
   `.Rcheck` directories, local libraries, generated UAT output, or private
   transcript/roster paths.
+- The frozen release candidate was built from commit
+  `8a1989ceb5c3650741b33a15abd1fe08a3ca03b5`. Its SHA-256 is
+  `db25dc366c4b27767da648be5004d70899ab009f2ddab8fe668dbed61439fc6c`.
+- Hosted checks on the release commit passed for R CMD check on Ubuntu,
+  Windows, and macOS, lint, package coverage, and pkgdown Pages deployment.
+  Overall coverage was 89.35%; coverage across the declared strategic exported
+  API was 93.33%.
+- R-devel win-builder completed with 0 errors, 0 warnings, and the 1 note
+  described above. Installation, examples, tests, vignettes, and PDF/HTML
+  manuals passed.
 
 ## Validation Status
 
@@ -62,5 +76,5 @@ check with incoming feasibility disabled completed with 0 errors, 0 warnings, an
 - [x] Tarball hygiene inspection passes
 - [x] Release-surface remediation PR #566 merged with passing CI
 - [x] Feature-surface hardening and final product-voice/privacy review complete
-- [ ] R-devel win-builder check complete
+- [x] R-devel win-builder check complete
 - [ ] Maintainer final release disposition recorded

--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -20,7 +20,7 @@
 - **Notes**: 1
 
 The R-devel win-builder note is the expected informational `New submission`
-note. Its incoming-feasibility output also identifies `WebVTT` (the transcript
+note. Its incoming feasibility output also identifies `WebVTT` (the transcript
 format name) and `reviewable` (an intentional English word) as possible
 misspellings. A canonical local check with incoming feasibility disabled
 completed with 0 errors, 0 warnings, and 0 notes.


### PR DESCRIPTION
## Summary

- record the successful R-devel win-builder result
- explain the expected new-submission note and legitimate `WebVTT` / `reviewable` spelling flags
- record the frozen release commit, tarball SHA-256, hosted checks, coverage, and installed-package UAT evidence
- leave maintainer release disposition open

## Frozen artifact

- source commit: `8a1989ceb5c3650741b33a15abd1fe08a3ca03b5`
- upload path: `/Users/piper/Downloads/engager-cran-0.1.0/engager_0.1.0.tar.gz`
- SHA-256: `db25dc366c4b27767da648be5004d70899ab009f2ddab8fe668dbed61439fc6c`
- tarball entries: 270; hygiene inspection passed
- installed-package UAT: PASS
- R-devel win-builder: 0 errors, 0 warnings, 1 expected/non-actionable note
- hosted R CMD check, lint, coverage, and Pages: passed

## Scope verification

Only `cran/cran-comments.md` changes. The `cran/` directory is excluded by `.Rbuildignore` and absent from the frozen tarball, whose SHA-256 remains unchanged.

## Boundaries

This PR does not upload to CRAN, mutate issue #4, recreate `v0.1.0`, publish a GitHub release, close the release ledger, or add package features.