### PR TITLE
fix: address CRAN WebVTT metadata review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,19 @@
 Package: engager
 Type: Package
-Title: Analyze Student Engagement from Zoom and WebVTT Transcripts
+Title: Analyze Student Engagement from 'WebVTT' Transcripts
 Version: 0.1.0
 Authors@R: person(given = "Conor",
                   family = "Healy",
                   role = c("aut", "cre"),
                   email = "conorhealy@berkeley.edu")
 Description: Analyzes participation in course-session transcripts stored in
-    WebVTT format. Provides tools to load and process transcripts, calculate
-    speaker-level engagement metrics, create privacy-supporting plots and
-    exports, and perform reviewable exact name matching against course rosters.
-    Structured-field masking and technical privacy-review helpers support local
-    review but do not determine legal or institutional compliance.
+    the 'WebVTT' format <https://www.w3.org/TR/webvtt1/>, including transcripts
+    exported by 'Zoom' and similar videoconferencing platforms. Provides tools
+    to load and process transcripts, calculate speaker-level engagement metrics,
+    create privacy-supporting plots and exports, and perform reviewable exact
+    name matching against course rosters. Structured-field masking and technical
+    privacy-review helpers support local review but do not determine legal or
+    institutional compliance.
 License: MIT + file LICENSE
 Depends: R (>= 4.1.0)
 Language: en-US

--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -8,10 +8,31 @@
 
 ## Test Environments
 
-- **Local**: macOS Tahoe 26.5.1, R 4.5.3 (2026-03-11), aarch64-apple-darwin20
+- **Local**: macOS Tahoe 26.5.2, R 4.5.3 (2026-03-11), aarch64-apple-darwin20
 - **GitHub Actions baseline**: Ubuntu, Windows, and macOS with R release
-- **R-devel win-builder**: Windows Server 2022 x64, R Under development
+- **Initial R-devel win-builder**: Windows Server 2022 x64, R Under development
   (2026-07-10 r90234 ucrt)
+
+## CRAN Reviewer Response
+
+The initial submission received this request from Uwe Ligges:
+
+> Possibly misspelled words in DESCRIPTION:
+> WebVTT (3:49, 10:5)
+>
+> Please single quote software names in both Title and Description fields
+> of the DESCRIPTION file.
+>
+> Is there some reference about the method you can add in the Description
+> field in the form Authors (year) <doi:10.....> or link tom the format in
+> the form <https://.....>?
+
+In response, the Title and Description now single-quote `WebVTT` and `Zoom`,
+and the Description links to the W3C specification for the WebVTT format:
+<https://www.w3.org/TR/webvtt1/>. The package calculates descriptive
+transcript-derived participation metrics rather than implementing a named
+published research method. `WebVTT` and `reviewable` were also added to the
+package spelling wordlist.
 
 ## R CMD Check Results
 
@@ -19,11 +40,12 @@
 - **Warnings**: 0
 - **Notes**: 1
 
-The R-devel win-builder note is the expected informational `New submission`
-note. Its incoming feasibility output also identifies `WebVTT` (the transcript
-format name) and `reviewable` (an intentional English word) as possible
-misspellings. A canonical local check with incoming feasibility disabled
-completed with 0 errors, 0 warnings, and 0 notes.
+The package note is the expected informational `New submission` note. A
+canonical local check with incoming feasibility disabled completed with 0
+errors, 0 warnings, and 0 notes. A network-enabled check of the exact
+replacement tarball completed with 0 errors, 0 warnings, and 2 notes: `New
+submission` and the local machine's outdated HTML Tidy. The previously reported
+`WebVTT` and `reviewable` spelling flags are no longer present.
 
 ## Reverse Dependencies
 
@@ -55,16 +77,17 @@ completed with 0 errors, 0 warnings, and 0 notes.
   project-only release documents, development scripts, nested archives,
   `.Rcheck` directories, local libraries, generated UAT output, or private
   transcript/roster paths.
-- The frozen release candidate was built from commit
-  `8a1989ceb5c3650741b33a15abd1fe08a3ca03b5`. Its SHA-256 is
-  `db25dc366c4b27767da648be5004d70899ab009f2ddab8fe668dbed61439fc6c`.
-- Hosted checks on the release commit passed for R CMD check on Ubuntu,
+- The replacement release candidate was built from package-content commit
+  `67918c4904c072e91f378f3bb3677d2ffdd35bda`. Its SHA-256 is
+  `2a8087a2b315fac48de8fa8239465d7360152dacf0c725d803e5cdeb50ce6ae1`.
+- Prior hosted baseline checks passed for R CMD check on Ubuntu,
   Windows, and macOS, lint, package coverage, and pkgdown Pages deployment.
   Overall coverage was 89.35%; coverage across the declared strategic exported
   API was 93.33%.
-- R-devel win-builder completed with 0 errors, 0 warnings, and the 1 note
-  described above. Installation, examples, tests, vignettes, and PDF/HTML
-  manuals passed.
+- The replacement installed-package UAT passed, and tarball inspection again
+  found 270 clean entries with no project-only or private/local artifacts.
+- The exact replacement tarball was submitted to R-devel win-builder; its
+  emailed result is pending.
 
 ## Validation Status
 
@@ -76,5 +99,5 @@ completed with 0 errors, 0 warnings, and 0 notes.
 - [x] Tarball hygiene inspection passes
 - [x] Release-surface remediation PR #566 merged with passing CI
 - [x] Feature-surface hardening and final product-voice/privacy review complete
-- [x] R-devel win-builder check complete
+- [ ] Replacement R-devel win-builder check complete
 - [ ] Maintainer final release disposition recorded

--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -12,6 +12,8 @@
 - **GitHub Actions baseline**: Ubuntu, Windows, and macOS with R release
 - **Initial R-devel win-builder**: Windows Server 2022 x64, R Under development
   (2026-07-10 r90234 ucrt)
+- **Replacement R-devel win-builder**: Windows Server 2022 x64, R Under
+  development (2026-07-12 r90242 ucrt)
 
 ## CRAN Reviewer Response
 
@@ -44,8 +46,11 @@ The package note is the expected informational `New submission` note. A
 canonical local check with incoming feasibility disabled completed with 0
 errors, 0 warnings, and 0 notes. A network-enabled check of the exact
 replacement tarball completed with 0 errors, 0 warnings, and 2 notes: `New
-submission` and the local machine's outdated HTML Tidy. The previously reported
-`WebVTT` and `reviewable` spelling flags are no longer present.
+submission` and the local machine's outdated HTML Tidy. Replacement R-devel
+win-builder completed with 0 errors, 0 warnings, and 1 incoming-feasibility
+note: `New submission` plus `reviewable` as a possible misspelling. `reviewable`
+is an intentional English word. The reviewer-reported `WebVTT` flag is no
+longer present.
 
 ## Reverse Dependencies
 
@@ -86,8 +91,8 @@ submission` and the local machine's outdated HTML Tidy. The previously reported
   API was 93.33%.
 - The replacement installed-package UAT passed, and tarball inspection again
   found 270 clean entries with no project-only or private/local artifacts.
-- The exact replacement tarball was submitted to R-devel win-builder; its
-  emailed result is pending.
+- The exact replacement tarball passed R-devel win-builder installation,
+  examples, tests, vignettes, and PDF/HTML manual checks.
 
 ## Validation Status
 
@@ -99,5 +104,5 @@ submission` and the local machine's outdated HTML Tidy. The previously reported
 - [x] Tarball hygiene inspection passes
 - [x] Release-surface remediation PR #566 merged with passing CI
 - [x] Feature-surface hardening and final product-voice/privacy review complete
-- [ ] Replacement R-devel win-builder check complete
+- [x] Replacement R-devel win-builder check complete
 - [ ] Maintainer final release disposition recorded

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -35,6 +35,7 @@ Tibble
 UC
 validators
 Walkthrough
+WebVTT
 YYYY
 Za
 bolded
@@ -90,4 +91,5 @@ transcriptLoad
 UX
 engager
 runnable
+reviewable
 🛠️


### PR DESCRIPTION
## CRAN reviewer request

Uwe Ligges requested that software names in the Title and Description be single-quoted and asked for a published method reference or a link to the format.

## Remediation

- center the Title on the supported `WebVTT` format
- single-quote `WebVTT` and `Zoom` in package metadata
- cite the authoritative W3C WebVTT specification
- add `WebVTT` and `reviewable` to the package spelling wordlist
- preserve the reviewer wording and validation evidence in `cran/cran-comments.md`

The package computes descriptive transcript-derived participation metrics rather than implementing a named published research method, so the W3C format specification is the accurate reference.

## Validation

- full source tests: 0 failures; 67 expected warning-path assertions; 5 documented skips
- canonical `devtools::check(..., --as-cran)`: 0 errors, 0 warnings, 0 notes
- exact replacement tarball check: 0 errors, 0 warnings; expected `New submission` plus local outdated HTML Tidy note; prior spelling flags absent
- installed-package UAT: PASS
- tarball hygiene: 270 clean entries
- package-content commit: `67918c4904c072e91f378f3bb3677d2ffdd35bda`
- replacement SHA-256: `2a8087a2b315fac48de8fa8239465d7360152dacf0c725d803e5cdeb50ce6ae1`
- replacement R-devel win-builder submission: uploaded; emailed result pending

## Boundaries

No feature, API, schema, dependency, privacy behavior, or version change is included. This PR does not resubmit to CRAN, reply to the reviewer, recreate `v0.1.0`, publish a GitHub release, or close issue #4.