### PR TITLE
docs: add post-CRAN product roadmap

### DIFF
--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -9,7 +9,8 @@ pre-scope-reduction API, and 122 live open GitHub issues. The existing
 refreshed before it authorizes any live mutation.
 
 This roadmap governs product direction. GitHub issues remain the execution
-ledger; `project-docs/release/V0_1_1_RELEASE_PLAN.md` governs the next release.
+ledger; [release/V0_1_1_RELEASE_PLAN.md](release/V0_1_1_RELEASE_PLAN.md) governs
+the next release.
 
 ## Product promise
 
@@ -63,7 +64,7 @@ release, and issue #4 closeout described in the 0.1.1 release plan are approved.
 Commitment: next feature release.
 
 The complete scope, dependency-ordered tranches, gates, and mutation boundaries
-are in `project-docs/release/V0_1_1_RELEASE_PLAN.md`.
+are in [release/V0_1_1_RELEASE_PLAN.md](release/V0_1_1_RELEASE_PLAN.md).
 
 Outcome: a user can analyze a synthetic or locally held course roster and
 multiple session transcripts, understand failed/unmatched inputs, and create an

--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -1,0 +1,257 @@
+# `engager` Product Roadmap
+
+Status: product and release planning source of truth.
+
+Last reconciled: 2026-07-14 against `main` at
+`50188a1ae17fa646dc5792b52992db7210192b85`, 35 current exports, the historical
+pre-scope-reduction API, and 122 live open GitHub issues. The existing
+`project-docs/backlog-normalization` snapshot contains 128 issues and must be
+refreshed before it authorizes any live mutation.
+
+This roadmap governs product direction. GitHub issues remain the execution
+ledger; `project-docs/release/V0_1_1_RELEASE_PLAN.md` governs the next release.
+
+## Product promise
+
+`engager` helps instructors and researchers turn locally held WebVTT course
+transcripts into reviewable participation evidence. It should make common
+analysis easy, preserve uncertainty, minimize identifier exposure, and avoid
+turning participation measurements into unsupported judgments about students.
+
+## Roadmap principles
+
+1. **Local and reviewable by default.** No telemetry or automatic external data
+   transfer. Derived results retain enough provenance to be audited locally.
+2. **Privacy-supporting, not compliance-certifying.** Masking, hashing,
+   pseudonymization, aggregation, and review helpers are technical operations.
+   They do not establish anonymity, FERPA compliance, or institutional approval.
+3. **Exact before probabilistic.** Exact roster matching remains the supported
+   default. Any future fuzzy assistance must be review-only, preserve ambiguity,
+   and never silently assign identities.
+4. **One coherent workflow per release.** A release should solve one user job
+   end to end, including installed-package UAT, rather than expose a collection
+   of partially related helpers.
+5. **Public APIs are earned.** Internal helpers become exports only when their
+   contract, error semantics, documentation, privacy behavior, and installed use
+   are proven.
+6. **Synthetic evidence only.** Tests and committed validation artifacts use
+   bundled synthetic fixtures, never real or private course data.
+7. **Accepted release lines stay immutable.** Post-0.1.0 package work uses a
+   development version and targets 0.1.1 or later.
+
+## Release sequence
+
+### 0.1.0 — Focused transcript-analysis foundation
+
+Status: submitted to CRAN; awaiting public acceptance at this reconciliation.
+
+Supported product:
+
+- WebVTT loading, processing, and consolidation.
+- Speaker-level engagement metrics and plots.
+- Privacy-supporting metric exports.
+- Exact roster matching and unresolved-name review.
+- Structured identifier masking, hashing with caller-provided salt, and
+  pseudonymization.
+- Beginner, composable, and batch transcript workflows.
+
+No post-release work begins until the acceptance reconciliation, tag, GitHub
+release, and issue #4 closeout described in the 0.1.1 release plan are approved.
+
+### 0.1.1 — Multi-session attendance and reviewable reports
+
+Commitment: next feature release.
+
+The complete scope, dependency-ordered tranches, gates, and mutation boundaries
+are in `project-docs/release/V0_1_1_RELEASE_PLAN.md`.
+
+Outcome: a user can analyze a synthetic or locally held course roster and
+multiple session transcripts, understand failed/unmatched inputs, and create an
+aggregate report that does not reveal raw participant names by default.
+
+### 0.1.2 — Privacy-safe sharing and reliability
+
+Candidate scope; confirm after 0.1.1 user feedback.
+
+- Design a distinct aggregation API that accepts explicit grouping keys and
+  permitted metrics and cannot carry row-level identifiers or free text.
+- Define minimum-group and disclosure-review behavior without calling the output
+  anonymous or compliant.
+- Unify identifier transformations and provenance metadata around issue #341.
+- Add privacy-sensitive operation audit records without logging identifiers,
+  informed by issue #381.
+- Standardize file-write errors and atomic output behavior, informed by issue
+  #438.
+- Publish stable result and output schemas with schema-version metadata.
+- Add a machine-readable analysis manifest containing package version, input
+  fingerprints rather than paths or names, parameters, warnings/problems, and
+  output checksums.
+
+Generic aggregate mode does not return merely because this version exists. It
+returns only after its disclosure contract and adversarial privacy tests pass.
+
+### 0.2.0 — Course-project workflows and broader inputs
+
+Candidate scope; revalidate demand and dependencies after the 0.1.x releases.
+
+- A supported course configuration object for roster, session, cancellation,
+  threshold, and output settings.
+- Strict input contracts and actionable unsupported-file guidance, aligned with
+  issues #196 and #197.
+- Deliberate support for additional Zoom artifacts such as closed captions or
+  chat only after separate privacy and schema review, aligned with issue #97.
+- Batch export built on the stable report schema, aligned with issue #441.
+- Optional, dependency-light spreadsheet output only if user demand justifies
+  it; issues #440 and #453 do not by themselves justify a core dependency.
+- A project template or reproducible analysis scaffold if it adds value beyond
+  the existing beginner workflow.
+- Consolidated, progressive tutorials rather than wholesale restoration of
+  disabled legacy vignettes, informed by issue #334.
+
+### 0.3.0 and later — Scale, longitudinal questions, and ecosystem
+
+Exploratory, not committed.
+
+- Evidence-driven large-file improvements: chunked input, memory limits, and
+  benchmark budgets only where measurements show a user-visible constraint.
+- Longitudinal course-level trends with explicit missingness and cohort-change
+  semantics.
+- Participant-level longitudinal reporting only after an ethical-use review,
+  a narrow purpose statement, strong default masking, and tests against ranking
+  or risk-scoring misuse.
+- Review-assisted fuzzy matching only as a separate, auditable suggestion layer.
+- Reusable parser, privacy, or CI components may become separate packages only
+  when maintenance and user demand justify the split.
+
+## Historical feature disposition
+
+The package once exposed as many as 85 functions. Immediately before the major
+scope reduction at commit `e258ef5`, it exposed 74; the current package exposes
+35. Most removed names were internal machinery, duplicate wrappers, development
+tools, or APIs without stable semantics. Historical presence is evidence to
+review a capability, not a reason to restore its old interface.
+
+| Historical capability | Representative former or internal functions | Disposition | Target |
+|---|---|---|---|
+| Multi-session attendance | `analyze_multi_session_attendance()`, `make_student_roster_sessions()` | Redesign and graduate with explicit roster, denominator, failure, and privacy contracts | 0.1.1 |
+| Attendance and student reports | `generate_attendance_report()`, `run_student_reports()` | Restore aggregate attendance reporting under the new API; permanently retire the old raw student-report interface | 0.1.1; longitudinal work no earlier than 0.3.0 |
+| Generic aggregate transformation | Former `anonymize_educational_data(method = "aggregate")` | Redesign as a separate aggregation contract; never restore the row-preserving implementation | Candidate 0.1.2 |
+| Course/session configuration | `create_analysis_config()`, `create_course_info()`, `create_session_mapping()`, `load_session_mapping()`, `load_cancelled_classes()` | Keep internal through 0.1.1; promote one coherent configuration object only if it simplifies the course workflow | Candidate 0.2.0 |
+| Ideal-course batch processing | `process_ideal_course_batch()`, `compare_ideal_sessions()` | Preserve the synthetic scenarios as fixtures; implement user value through supported batch/course workflows, not the old API | Fixtures now; product behavior 0.1.1–0.2.0 |
+| Ideal-course export and validation | `export_ideal_transcripts_csv()`, `export_ideal_transcripts_json()`, `export_ideal_transcripts_excel()`, `export_ideal_transcripts_summary()`, `calculate_content_similarity()`, `validate_ideal_content_quality()`, `validate_ideal_name_coverage()`, `validate_ideal_scenarios()`, `validate_ideal_timing_consistency()`, `validate_ideal_transcript_comprehensive()`, and `validate_ideal_transcript_structure()` | Keep validation as test infrastructure. Do not restore synthetic-data-specific public exports; general reporting owns output | Tests now; general exports 0.1.1–0.2.0 |
+| One-call transcript processing | `load_and_process_zoom_transcript()`, proposed issue #198 orchestration | Superseded by `basic_transcript_analysis()`, `quick_analysis()`, and the composable workflow; reconcile issue rather than add another wrapper | Retire/reconcile |
+| Specialized plotting wrappers | `plot_users_by_metric()`, `plot_users_masked_section_by_metric()` | Superseded by parameterized `plot_users()`; add capabilities to the canonical plot API only when needed | Retire old names |
+| Legacy metric writers | `write_engagement_metrics()`, `write_transcripts_summary()`, `write_transcripts_session_summary()` | Superseded by `write_metrics()` and future report outputs. Retain lower-level writers internally only while used | Retire/internal |
+| Name/lookup internals | `safe_name_matching_workflow()`, `match_names_with_privacy()`, `prompt_name_matching()`, `hash_name_consistently()`, `load_section_names_lookup()`, `make_clean_names_df()`, `make_names_to_clean_df()`, `merge_lookup_preserve()`, `read_lookup_safely()`, `write_lookup_transactional()` | Keep internal behind the exact public matching workflow; do not expose implementation fragments or interactive prompts | Internal |
+| Session and summary internals | `join_transcripts_list()`, `load_transcript_files_list()`, `load_zoom_recorded_sessions_list()`, `make_transcripts_summary_df()`, `make_transcripts_session_summary_df()`, `make_students_only_transcripts_summary_df()` | Retain and harden as implementation details. Promote only stable result objects, not assembly helpers | Internal |
+| Participant classification | `classify_participants()`, `ensure_instructor_rows()` | Fold only the necessary, explicit roles into the attendance contract; do not infer student status from names | 0.1.1 contract/internal |
+| Privacy and ethics reports | `audit_ethical_usage()`, `create_ethical_use_report()`, `generate_ferpa_report()`, `validate_ethical_use()`, `validate_ferpa_compliance()`, `check_data_retention_policy()` | Preserve useful technical checks behind current review APIs; do not restore compliance-branded promises | 0.1.2 review, mostly internal |
+| Privacy defaults and processing wrappers | `set_privacy_defaults()`, `mask_user_names_by_metric()`, `process_transcript_with_privacy()` | Avoid hidden global mutation and redundant workflow wrappers. Use explicit per-call configuration and canonical transformation/plot functions | 0.1.1–0.1.2 |
+| Schema validation | `validate_schema()` | Replace ad hoc public validation with documented result/output schemas and internal validators | Candidate 0.1.2 |
+| Analysis template generation | `make_new_analysis_template()` | Reassess as a reproducible course-project scaffold; do not restore an unmaintained R Markdown template | Candidate 0.2.0 |
+| Function inventory and deprecation tooling | `get_deprecated_functions()`, `get_essential_functions()`, `get_internal_functions()`, `get_scope_reduction_summary()` | Repository governance tooling, not package functionality. Keep out of the public API | Retired from package |
+| Coverage, diagnostics, CRAN, and benchmark helpers | `benchmark_ideal_transcripts()`, `diag_cat()`, `diag_message()`, and removed coverage, CRAN optimization, scope-reduction, and test-quality functions | Implement through tests, scripts, and CI; never expose as user-facing package APIs | Repository maintenance |
+| Pipe export | `%>%` | Dependency plumbing, not a product feature. Prefer qualified or base-pipe examples | Do not restore |
+
+Additional internal helpers such as `add_dead_air_rows()`,
+`detect_duplicate_transcripts()`, `make_blank_cancelled_classes_df()`,
+`make_blank_section_names_lookup_csv()`, `make_roster_small()`,
+`make_sections_df()`, `make_semester_df()`, `make_metrics_lookup_df()`,
+`conditionally_write_lookup()`, and
+`write_section_names_lookup()` remain implementation details unless a future
+user workflow demonstrates a stable public contract.
+
+## Existing roadmap and backlog reconciliation
+
+The live backlog mixes product ideas, already-implemented work, duplicate debt,
+and old CRAN assumptions. Before issue mutation, refresh the normalization
+control artifacts and review each proposed change.
+
+### Product candidates to preserve and reframe
+
+- #50: topic parsing — consider within the 0.2.0 input/session contract.
+- #56: transcript-file identity and duplicate handling — reconcile against the
+  current internal detector and 0.1.1 session identity work.
+- #97: additional Zoom file types — 0.2.0, after privacy/schema review.
+- #148 and #341: identifier coverage and transformation unification — 0.1.2
+  privacy contract, not blanket anonymization.
+- #196 and #197: strict input behavior and unsupported-file guidance — 0.2.0.
+- #334: tutorial overhaul — deliver progressively with each supported workflow.
+- #365: VTT edge fixtures — useful as a reliability tranche, with synthetic data.
+- #381: privacy operation audit logging — 0.1.2, metadata only.
+- #403: metric-existence guards — reliability work after duplicate review.
+- #427–#429: ideal-course visualization/configuration follow-up — split fixtures
+  from genuine product needs; do not revive the old ideal-course API wholesale.
+- #437–#441 and #453: privacy, errors, scale, charts, and exports — route into the
+  release horizons above rather than one broad enhancement batch.
+
+### Likely duplicate, implemented, or stale premises to review
+
+- #147, #302, #344, and #364 overlap on warning and output noise.
+- #288 is substantially represented by the current hosted R CMD check matrix.
+- #296 mixes completed hosted checks with remaining style/spelling/coverage work.
+- #298 is substantially represented by current masking behavior.
+- #469 assumes a historical export count and cannot govern the current API.
+- #471 is performance infrastructure debt, not a CRAN or feature blocker.
+- #395 can remain a coordination umbrella but should not own implementation.
+
+Closure, supersession, duplicate marking, label deletion, and issue #4 closure
+remain human-only. Comments require an approved manifest/PR; labels, milestones,
+priority, status, and body changes require specific review.
+
+## Capabilities newly added to the roadmap
+
+These needs emerge from the current product contract and were not coherently
+represented by the legacy public API:
+
+1. **Versioned result schemas.** Attendance, matching, metrics, problems, and
+   report outputs need documented columns, types, units, and schema versions.
+2. **Analysis provenance manifest.** Record package version, parameter values,
+   non-identifying input fingerprints, problems, and output checksums for local
+   reproducibility without copying private source data.
+3. **Structured partial-failure reporting.** Batch and course workflows must
+   distinguish absent data, invalid data, failed processing, and true zeroes.
+4. **Disclosure-oriented report tests.** Scan all generated artifacts for raw
+   synthetic identifiers, free transcript text, small-cell risk markers, and
+   misleading compliance language.
+5. **API maturity policy.** Label new functions experimental until their
+   installed workflow, error behavior, and schema are stable; add exports only
+   at a release boundary.
+6. **Release-to-CRAN smoke matrix.** After each CRAN publication, test a fresh
+   installation and the advertised workflow before closing the release ledger.
+7. **Documented cancellation and missingness semantics.** Treat cancelled,
+   absent, unknown, unreadable, and unmatched states as distinct throughout
+   analysis and reporting.
+
+## Cross-cutting maintenance lane
+
+Maintenance work runs beside, not inside, feature tranches:
+
+- Refresh and review the 122-issue backlog snapshot in small mutation batches.
+- Consolidate warning-cleanup ownership and reduce the 67 expected warning-path
+  assertions without hiding real warnings.
+- Review the five documented skips and remove skips that conceal supported
+  behavior.
+- Resolve current lint findings incrementally; do not use broad mechanical
+  rewrites in release PRs.
+- Remove disabled vignettes, historical artifacts, stale generated documents,
+  and remote branches only after evidence and separate approval.
+- Make CI, coverage, lint, pkgdown, and release workflows report their true
+  scope and status.
+- Benchmark before optimizing. Large-file work must be triggered by measured
+  workload limits, not historical severity labels.
+
+## Promotion rules
+
+A candidate moves into a numbered release only when it has:
+
+- one named user job and a bounded public contract;
+- no duplicate implementation owner;
+- synthetic fixtures and acceptance examples;
+- explicit error, missingness, privacy, and output semantics;
+- an installed-package UAT plan;
+- documentation and migration implications;
+- a maintainer-approved release boundary.
+
+The next promotion decision occurs after 0.1.1 ships and fresh-user feedback is
+reviewed. Until then, 0.1.2 and later scopes are directional, not promises.

--- a/project-docs/release/PROJECT.md
+++ b/project-docs/release/PROJECT.md
@@ -1,3 +1,11 @@
+> **Current planning notice (2026-07-14):** This file contains historical,
+> generated status records with conflicting dates, metrics, and conclusions. It
+> is retained as project history, not as the current roadmap. Use
+> [`../ROADMAP.md`](../ROADMAP.md) for product direction and
+> [`V0_1_1_RELEASE_PLAN.md`](V0_1_1_RELEASE_PLAN.md) for the approved next-release
+> plan. Live GitHub, CRAN, package, and validation evidence outrank older sections
+> below.
+
 ### 📊 **PRD Audit Analysis (COMPLETED - 2025-01-27)**
 A comprehensive PRD audit was completed with **ACTIONABLE FINDINGS** for package optimization:
 
@@ -1614,4 +1622,3 @@ SOFTWARE.
 - [Issue #183]: Clarify privacy defaults in README and link FERPA vignette (privacy, docs, readme, priority: high)
 - [Issue #183]: Clarify privacy defaults in README and link FERPA vignette (privacy, docs, readme, priority: high)
 - [Issue #183]: Clarify privacy defaults in README and link FERPA vignette (privacy, docs, readme, priority: high)
-

--- a/project-docs/release/V0_1_1_RELEASE_PLAN.md
+++ b/project-docs/release/V0_1_1_RELEASE_PLAN.md
@@ -1,0 +1,191 @@
+# `engager` 0.1.1 Release Plan
+
+Status: approved planning baseline; execution is blocked until `engager` 0.1.0
+is publicly available from CRAN.
+
+Last reconciled: 2026-07-14 against `main` at
+`50188a1ae17fa646dc5792b52992db7210192b85` and the live GitHub backlog.
+
+## Release thesis
+
+Turn multiple session transcripts into reviewable course-attendance results
+without exposing raw participant names by default.
+
+Version 0.1.1 will graduate the retained internal attendance and reporting
+prototypes into a supported installed-package workflow. It is not a general
+reporting, longitudinal analytics, or anonymization release.
+
+## Entry gate: close version 0.1.0
+
+Do not change package content until both a CRAN acceptance message and the
+public CRAN package page exist.
+
+After publication:
+
+1. Download the published CRAN source tarball and calculate its SHA-256.
+2. Compare it with the submitted replacement artifact SHA-256:
+   `2a8087a2b315fac48de8fa8239465d7360152dacf0c725d803e5cdeb50ce6ae1`.
+3. Install from CRAN in an isolated library and run the beginner smoke workflow.
+4. Update issue #4 with the CRAN URL, publication date, published checksum,
+   reviewer-remediation history, package-content commit
+   `67918c4904c072e91f378f3bb3677d2ffdd35bda`, and main-line evidence commit
+   `50188a1ae17fa646dc5792b52992db7210192b85`.
+5. Obtain explicit approval before creating the annotated `v0.1.0` tag at the
+   accepted package-content commit, publishing the GitHub release, or closing
+   issue #4.
+6. Open a separate kickoff PR that changes the development version to
+   `0.1.0.9000` and adds an `engager 0.1.1` NEWS section. The development suffix
+   identifies work toward 0.1.1; the accepted 0.1.0 source remains unchanged.
+
+## Product boundary
+
+### Included
+
+- Deterministic session identity and ordering, including the unknown-timestamp
+  behavior tracked by issue #560.
+- Exact roster-based attendance across multiple transcripts.
+- Explicit absent, unmatched, failed-session, cancelled-session, threshold,
+  and denominator semantics.
+- Course-level and session-level attendance summaries.
+- Aggregate reports by default, with no raw participant identifiers or
+  transcript text.
+- Explicitly requested participant detail using a supported masking or
+  pseudonymization mode.
+- Public, documented versions of `analyze_multi_session_attendance()` and
+  `generate_attendance_report()`.
+- Installed-tarball UAT using bundled synthetic fixtures only.
+
+### Excluded
+
+- `anonymize_educational_data(method = "aggregate")` or any generic claim of
+  anonymization.
+- Fuzzy roster matching.
+- Longitudinal student profiles or risk scoring.
+- Chat, closed-caption, or non-WebVTT ingestion expansion.
+- Excel-specific output or chart generation.
+- Broad API trimming, performance refactors, CI modernization, warning cleanup,
+  and backlog normalization.
+- Real or private course data.
+
+## Delivery tranches
+
+Each tranche starts from current `origin/main` in a dedicated worktree. Before
+delegation, scan live issues, PRs, branches, and worktrees for duplicate
+ownership. Each implementation PR runs targeted tests, full tests,
+`devtools::document()`, `git diff --check`, and the hosted required checks.
+
+### T0 — Development kickoff
+
+- Branch: `codex/v011-kickoff`
+- Worktree: `engager-v011-kickoff`
+- Deliverables: `0.1.0.9000`, a 0.1.1 NEWS section, and one v0.1.1 umbrella
+  issue or milestone.
+- Acceptance: metadata-only; no behavior change and no alteration of 0.1.0
+  acceptance evidence.
+
+### T1 — Attendance contract and golden fixtures
+
+- Branch: `codex/v011-attendance-contract`
+- Worktree: `engager-v011-attendance-contract`
+- Decide and document the roster authority, unresolved-speaker handling,
+  absence versus failed-session semantics, denominator rules, threshold
+  inclusivity, duplicate-session behavior, cancelled-session behavior, result
+  schema, and privacy metadata.
+- Add synthetic contract tables for zero attendance, full attendance, an
+  unmatched instructor or guest, duplicate inputs, failed inputs, blank
+  identifiers, and threshold boundaries.
+- Gate: maintainer approves the contract. Institutional policy must not be
+  inferred from implementation convenience.
+
+### T2 — Session identity and ordering
+
+- Branch: `codex/v011-session-identity`
+- Worktree: `engager-v011-session-identity`
+- Resolve issue #560: retain a stable derived session key, use `NA` for unknown
+  recording times, order known sessions chronologically, order unknown sessions
+  deterministically, and issue one specific warning for unparseable times.
+- Acceptance: Zoom and non-Zoom synthetic cases, mixed known/unknown times,
+  duplicate keys, and repeated-run stability all pass.
+
+### T3 — Exact roster-based attendance engine
+
+- Branch: `codex/v011-attendance-engine`
+- Worktree: `engager-v011-attendance-engine`
+- Use the package's exact matching path and the approved attendance contract.
+- Return a typed result, tentatively `engager_attendance`, with an explicit
+  eligible-session count and structured problems table.
+- Fail fast by default for missing or unreadable inputs. A permissive mode, if
+  approved, must never silently remove failed sessions from a denominator.
+- Keep unresolved speakers separate from roster attendance and do not mutate
+  global privacy options.
+- Acceptance: contract tests plus installed use of bundled synthetic VTT and
+  roster fixtures.
+
+### T4 — Privacy-safe reports
+
+- Branch: `codex/v011-attendance-report`
+- Worktree: `engager-v011-attendance-report`
+- Default to aggregate course/session summaries.
+- Require explicit opt-in and a supported transformation for participant-level
+  detail.
+- Propagate the analysis threshold instead of using a hard-coded report value.
+- Isolate generated timestamps as metadata so report content remains
+  deterministic under test.
+- Use technical review and masking language, not `privacy_compliant`, FERPA
+  compliance, or anonymity claims.
+- Document small-cohort and contextual disclosure risks.
+- Acceptance: generated artifacts contain no bundled raw identifiers or free
+  transcript text by default; opt-in and missing/blank behavior are tested.
+
+### T5 — Public API, documentation, and installed UAT
+
+- Branch: `codex/v011-attendance-public-api`
+- Worktree: `engager-v011-attendance-public-api`
+- Export only `analyze_multi_session_attendance()` and
+  `generate_attendance_report()` from this feature family.
+- Update roxygen/Rd, `NAMESPACE`, `_pkgdown.yml`, README, NEWS, and one active
+  vignette. Do not revive disabled legacy vignettes wholesale.
+- Extend the installed-package UAT to cover the export allowlist, a three-session
+  course, ordering, denominators, unresolved speakers, aggregate-default output,
+  masked opt-in output, and raw-identifier absence.
+- Acceptance: additive API; existing 0.1.0 exports and behavior remain compatible.
+
+### T6 — Release candidate
+
+- Branch: `codex/release-v0.1.1`
+- Worktree: `engager-release-v011`
+- Bump to `0.1.1`, finalize NEWS and `cran/cran-comments.md`, and make no
+  unrelated changes.
+- Build one release candidate from a clean committed head and record its commit,
+  SHA-256, R/platform details, commands, warnings, skips, and UAT disposition.
+
+## Release gates
+
+A GO disposition requires:
+
+- The approved attendance contract is implemented without unresolved semantic
+  decisions.
+- Default reports contain no raw participant identifiers or transcript text.
+- The package makes no unsupported anonymity, legal, or institutional-compliance
+  claim.
+- Existing 0.1.0 exports remain compatible and only the two reviewed attendance
+  functions are added.
+- Full tests have zero failures; every remaining warning and skip is explained.
+- `R CMD check --as-cran` has zero errors and warnings and only explained notes.
+- Hosted Linux, Windows, and macOS checks, coverage, lint, and documentation
+  checks pass at the exact release head.
+- The exact source tarball passes hygiene inspection and installed-package UAT.
+- R-devel win-builder and a documented current secondary remote check complete.
+- The maintainer approves the exact candidate checksum before manual upload.
+
+Any package-content change invalidates the candidate and requires a new build,
+check, privacy scan, and installed-package UAT. CRAN reviewer feedback receives
+one bounded remediation branch. The `v0.1.1` tag and GitHub release wait for CRAN
+publication and separate approval.
+
+## Work that must stay separate
+
+Backlog normalization, stale-branch cleanup, disabled-vignette cleanup, test
+warning reduction, lint cleanup, CI modernization, performance work, and generic
+aggregation design are valuable post-CRAN work. They must use separate control
+or maintenance PRs and cannot expand the v0.1.1 feature PRs or release candidate.

--- a/project-docs/release/V0_1_1_RELEASE_PLAN.md
+++ b/project-docs/release/V0_1_1_RELEASE_PLAN.md
@@ -30,10 +30,22 @@ After publication:
    reviewer-remediation history, package-content commit
    `67918c4904c072e91f378f3bb3677d2ffdd35bda`, and main-line evidence commit
    `50188a1ae17fa646dc5792b52992db7210192b85`.
-5. Obtain explicit approval before creating the annotated `v0.1.0` tag at the
+5. In a fresh clone, make the accepted package-content commit reachable through
+   the preserved PR #572 pull ref, then verify the object before tagging:
+
+   ```sh
+   git fetch origin refs/pull/572/head:refs/remotes/origin/pr/572
+   git cat-file -e 67918c4904c072e91f378f3bb3677d2ffdd35bda^{commit}
+   ```
+
+   PR #572's final head descends from this commit. The later squash commit
+   changes only `cran/cran-comments.md`, which is excluded from the package
+   tarball, but the release tag remains anchored to the exact accepted package
+   content.
+6. Obtain explicit approval before creating the annotated `v0.1.0` tag at the
    accepted package-content commit, publishing the GitHub release, or closing
    issue #4.
-6. Open a separate kickoff PR that changes the development version to
+7. Open a separate kickoff PR that changes the development version to
    `0.1.0.9000` and adds an `engager 0.1.1` NEWS section. The development suffix
    identifies work toward 0.1.1; the accepted 0.1.0 source remains unchanged.
 


### PR DESCRIPTION
## Summary

- memorialize the approved post-CRAN and 0.1.1 release plan
- establish a release-oriented product roadmap through 0.3.0+
- reconcile previously removed and internalized functionality with explicit restore, redesign, retain, supersede, or retire dispositions
- mark the historical generated PROJECT.md as non-authoritative for current planning

## Why

The initial CRAN release intentionally narrowed the package to a coherent supported core. The next phase needs a durable plan that distinguishes the two intentionally deferred attendance exports and unsafe aggregate mode from the much larger historical API reduction. Without that distinction, old roadmap records and stale issue premises could drive duplicate or unsafe restoration work.

## Impact

This PR changes documentation only. It does not change DESCRIPTION, NAMESPACE, R code, tests, active vignettes, bundled fixtures, or the submitted CRAN package payload. Version 0.1.0 remains frozen while CRAN review is pending.

The committed v0.1.1 scope is multi-session attendance and privacy-safe aggregate reporting. Later release horizons remain directional and require their own promotion decisions.

## Validation

- git diff --check: PASS
- historical export disposition audit: PASS, all 70 peak-era exports absent today are accounted for
- relative planning links: PASS
- repository status was clean before publication

## Mutation boundaries

- no GitHub issue, label, milestone, tag, or release mutation in this PR
- backlog normalization artifacts remain stale at 128 issues versus the 122-issue live baseline and cannot authorize mutations as-is
- no feature implementation starts before public CRAN acceptance and the approved 0.1.0 closeout
