### PR TITLE
chore: start 0.1.1 development

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: engager
 Type: Package
 Title: Analyze Student Engagement from 'WebVTT' Transcripts
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: person(given = "Conor",
                   family = "Healy",
                   role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# engager 0.1.1 (development version)
+
+* Began development of multi-session attendance analysis and reviewable,
+  privacy-supporting reports. The public API remains unchanged during the
+  contract and validation tranches.
+
 # engager 0.1.0
 
 ## Initial CRAN Submission

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # engager 0.1.1 (development version)
 
-* Began development of multi-session attendance analysis and reviewable,
-  privacy-supporting reports. The public API remains unchanged during the
-  contract and validation tranches.
+* No user-facing changes yet.
 
 # engager 0.1.0
 


### PR DESCRIPTION
## Outcome

Starts the isolated 0.1.1 development line by setting the development version
to `0.1.0.9000` and adding the unreleased 0.1.1 NEWS section.

Tracks #576.

## Change class

- [x] Routine
- [ ] Governed — maintainer authorization is linked below
- [ ] Release/external mutation — separate approval is linked below

Authorization/evidence link, if required: approved parallel-development and
process-cutover plans in the maintainer's orchestration task.

## Impact

- Package or user behavior: none; metadata only.
- Public API or result schema: unchanged.
- Privacy, disclosure, or data handling: unchanged.
- CRAN/release line: targets `develop`; `main` and the submitted 0.1.0 package
  remain untouched.

## Validation

- [x] Targeted tests (metadata diff and `git diff --check`)
- [x] `Rscript scripts/pre-pr-validation.R`
- [x] Generated documentation is committed and drift-free, if applicable — not
  applicable because no generated documentation changed
- [x] Installed-package UAT, if required by the release tranche — not required
  for T0
- [x] Only synthetic fixtures and temporary outputs were used

Exact commands and results:

- `git diff --check` — pass
- `Rscript scripts/pre-pr-validation.R` — pass without repository mutation
- Tests — 0 failures; 67 documented warning-path assertions; 5 documented skips
- Local `R CMD check --as-cran` — 0 errors, 0 warnings, 2 environment/development
  notes (offline incoming/time checks and development-version components)
- Exact head `40a33f2` — hosted Linux, macOS, Windows R CMD check, Coverage,
  and advisory lint all passed
- Gemini NEWS-tone finding — fixed in `40a33f2`; reply posted and thread resolved

## Review disposition

- [x] Actionable automated-review findings are fixed or explicitly declined
- [x] All review threads are resolved
- [x] Required hosted checks pass at this exact head, or an authorized
  CI-degraded evidence packet is linked

## Risk and rollback

Risk is limited to incorrect development metadata. Hosted checks validate the
exact head; a squash revert restores the prior metadata if needed.

## User-facing release note

Not user-facing; this establishes the 0.1.1 development line.
