### PR TITLE
fix: preserve unknown session times

### DIFF
--- a/R/load_transcript_files_list.R
+++ b/R/load_transcript_files_list.R
@@ -31,11 +31,12 @@ load_transcript_files_list <-
     # Use base R operations instead of dplyr to avoid segmentation fault
     # Create data frame with file names
     df <- data.frame(file_name = transcript_files, stringsAsFactors = FALSE)
+    df$session_key <- derive_transcript_session_key(df$file_name)
 
     # Extract date
     df$date_extract <- stringr::str_extract(df$file_name, dt_extract_pattern)
     missing_date <- is.na(df$date_extract) | !nzchar(df$date_extract)
-    df$date_extract[missing_date] <- derive_transcript_session_key(df$file_name[missing_date])
+    df$date_extract[missing_date] <- df$session_key[missing_date]
 
     # Determine file type
     df$file_type <- ifelse(
@@ -54,29 +55,49 @@ load_transcript_files_list <-
 
     # Extract and parse recording start time
     recording_start_str <- stringr::str_extract(df$file_name, recording_start_pattern)
-    df$recording_start <- lubridate::parse_date_time(recording_start_str, orders = recording_start_format)
-    df$recording_start <- as.POSIXct(df$recording_start, tz = "UTC")
+    df$recording_start <- as.POSIXct(
+      recording_start_str,
+      format = recording_start_format,
+      tz = "UTC"
+    )
     missing_start <- is.na(df$recording_start)
     if (any(missing_start)) {
-      fallback_session_keys <- unique(df$date_extract[missing_start])
-      fallback_recording_start <- as.POSIXct(
-        seq_along(fallback_session_keys),
-        origin = "1970-01-01",
-        tz = "UTC"
-      )
-      names(fallback_recording_start) <- fallback_session_keys
-      df$recording_start[missing_start] <- as.POSIXct(
-        fallback_recording_start[df$date_extract[missing_start]],
-        origin = "1970-01-01",
-        tz = "UTC"
+      unknown_session_count <- length(unique(df$session_key[missing_start]))
+      warning(
+        sprintf(
+          paste0(
+            "Recording time could not be parsed for %d session%s; ",
+            "recording_start and start_time_local remain NA. ",
+            "Unknown-time sessions are ordered by session_key."
+          ),
+          unknown_session_count,
+          if (unknown_session_count == 1L) "" else "s"
+        ),
+        call. = FALSE
       )
     }
     df$start_time_local <- lubridate::with_tz(df$recording_start, tzone = start_time_local_tzone)
 
-    # Pivot to wide format per recording using base R
-    groups_df <- unique(df[, c("date_extract", "recording_start", "start_time_local"), drop = FALSE])
-    # Ensure groups are ordered by time
-    groups_df <- groups_df[order(groups_df$start_time_local), , drop = FALSE]
+    # Pivot to wide format per stable session key using base R.
+    first_session_row <- match(unique(df$session_key), df$session_key)
+    groups_df <- df[
+      first_session_row,
+      c("session_key", "date_extract", "recording_start", "start_time_local"),
+      drop = FALSE
+    ]
+
+    # Known sessions sort chronologically. Unknown sessions sort after them by
+    # stable session key rather than by a fabricated timestamp or input order.
+    known_rows <- which(!is.na(groups_df$recording_start))
+    unknown_rows <- which(is.na(groups_df$recording_start))
+    known_rows <- known_rows[order(
+      groups_df$recording_start[known_rows],
+      groups_df$session_key[known_rows]
+    )]
+    unknown_rows <- unknown_rows[order(groups_df$session_key[unknown_rows])]
+    groups_df <- groups_df[c(known_rows, unknown_rows), , drop = FALSE]
+    rownames(groups_df) <- NULL
+
     # Initialize result with groups
     result <- groups_df
 
@@ -89,11 +110,13 @@ load_transcript_files_list <-
     # Fill in file names per group and type
     if (nrow(result) > 0) {
       for (k in seq_len(nrow(result))) {
-        row_date <- result$date_extract[k]
-        row_start <- result$recording_start[k]
+        row_session_key <- result$session_key[k]
         for (file_type in file_types) {
-          type_files <- df[df$file_type == file_type & df$date_extract == row_date &
-            df$recording_start == row_start, "file_name", drop = TRUE]
+          type_files <- df[
+            df$file_type == file_type & df$session_key == row_session_key,
+            "file_name",
+            drop = TRUE
+          ]
           if (length(type_files) > 0) {
             result[[file_type]][k] <- type_files[1]
           }

--- a/R/load_transcript_files_list.R
+++ b/R/load_transcript_files_list.R
@@ -53,6 +53,30 @@ load_transcript_files_list <-
       )
     )
 
+    # One session may have one file of each supported type. Two files that map
+    # to the same session and type are ambiguous and must not be silently
+    # collapsed into one attendance input.
+    session_type_key <- paste(df$session_key, df$file_type, sep = "\r")
+    duplicate_session_type <- duplicated(session_type_key) |
+      duplicated(session_type_key, fromLast = TRUE)
+    if (any(duplicate_session_type)) {
+      duplicate_session_count <- length(unique(
+        df$session_key[duplicate_session_type]
+      ))
+      rlang::abort(
+        message = sprintf(
+          paste0(
+            "%d session%s %s duplicate files of the same type; ",
+            "session keys and file types must map uniquely."
+          ),
+          duplicate_session_count,
+          if (duplicate_session_count == 1L) "" else "s",
+          if (duplicate_session_count == 1L) "contains" else "contain"
+        ),
+        class = "engager_schema_error"
+      )
+    }
+
     # Extract and parse recording start time
     recording_start_str <- stringr::str_extract(df$file_name, recording_start_pattern)
     df$recording_start <- as.POSIXct(

--- a/tests/testthat/test-create_analysis_config.R
+++ b/tests/testthat/test-create_analysis_config.R
@@ -96,22 +96,30 @@ test_that("create_analysis_config validates input parameters", {
 test_that("create_analysis_config defaults discover bundled synthetic transcripts", {
   config <- create_analysis_config()
 
-  transcript_files <- load_transcript_files_list(
-    data_folder = config$paths$data_folder,
-    transcripts_folder = config$paths$transcripts_folder,
-    transcript_files_names_pattern = config$patterns$transcript_files_names,
-    dt_extract_pattern = config$patterns$dt_extract,
-    trnscrptflxtnsnpttrn = config$patterns$transcript_file_extension,
-    clsdcptnflxtnsnpttrn = config$patterns$closed_caption_file_extension,
-    recording_start_pattern = config$patterns$recording_start,
-    recording_start_format = config$patterns$recording_start_format,
-    start_time_local_tzone = config$patterns$start_time_local_tzone
+  expect_warning(
+    transcript_files <- load_transcript_files_list(
+      data_folder = config$paths$data_folder,
+      transcripts_folder = config$paths$transcripts_folder,
+      transcript_files_names_pattern = config$patterns$transcript_files_names,
+      dt_extract_pattern = config$patterns$dt_extract,
+      trnscrptflxtnsnpttrn = config$patterns$transcript_file_extension,
+      clsdcptnflxtnsnpttrn = config$patterns$closed_caption_file_extension,
+      recording_start_pattern = config$patterns$recording_start,
+      recording_start_format = config$patterns$recording_start_format,
+      start_time_local_tzone = config$patterns$start_time_local_tzone
+    ),
+    "Recording time could not be parsed for [0-9]+ sessions"
   )
 
   expect_gt(nrow(transcript_files), 0)
+  expect_true("session_key" %in% names(transcript_files))
   expect_true("transcript_file" %in% names(transcript_files))
   expect_true(any(transcript_files$transcript_file == "intro_statistics_week1.vtt"))
-  expect_false(any(is.na(transcript_files$recording_start)))
+  expect_true(any(is.na(transcript_files$recording_start)))
+  expect_identical(
+    is.na(transcript_files$recording_start),
+    is.na(transcript_files$start_time_local)
+  )
 })
 
 test_that("create_analysis_config works with edge cases", {

--- a/tests/testthat/test-load_transcript_files_list.R
+++ b/tests/testthat/test-load_transcript_files_list.R
@@ -126,6 +126,28 @@ test_that("load_transcript_files_list orders known and unknown sessions determin
   expect_true(all(is.na(first$start_time_local[3:4])))
 })
 
+test_that("load_transcript_files_list rejects colliding session and file types", {
+  temp_dir <- tempfile()
+  transcripts_dir <- file.path(temp_dir, "transcripts")
+  dir.create(transcripts_dir, recursive = TRUE)
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+
+  file.create(
+    file.path(transcripts_dir, "lecture.vtt"),
+    file.path(transcripts_dir, "lecture.transcript.vtt")
+  )
+
+  expect_error(
+    load_transcript_files_list(
+      data_folder = temp_dir,
+      transcripts_folder = "transcripts",
+      transcript_files_names_pattern = "lecture"
+    ),
+    "1 session contains duplicate files of the same type",
+    class = "engager_schema_error"
+  )
+})
+
 test_that("load_transcript_files_list handles empty folder gracefully", {
   temp_dir <- tempdir()
   transcripts_dir <- file.path(temp_dir, "transcripts")

--- a/tests/testthat/test-load_transcript_files_list.R
+++ b/tests/testthat/test-load_transcript_files_list.R
@@ -62,17 +62,68 @@ test_that("load_transcript_files_list groups non-Zoom transcript siblings by ses
     file.path(transcripts_dir, "session1.chat.vtt")
   )
 
-  result <- load_transcript_files_list(
-    data_folder = temp_dir,
-    transcripts_folder = "transcripts",
-    transcript_files_names_pattern = "session1"
+  expect_warning(
+    result <- load_transcript_files_list(
+      data_folder = temp_dir,
+      transcripts_folder = "transcripts",
+      transcript_files_names_pattern = "session1"
+    ),
+    "Recording time could not be parsed for 1 session"
   )
 
   expect_equal(nrow(result), 1)
+  expect_equal(result$session_key, "session1")
   expect_equal(result$date_extract, "session1")
+  expect_true(is.na(result$recording_start))
+  expect_true(is.na(result$start_time_local))
   expect_equal(result$transcript_file, "session1.transcript.vtt")
   expect_equal(result$closed_caption_file, "session1.cc.vtt")
   expect_equal(result$chat_file, "session1.chat.vtt")
+})
+
+test_that("load_transcript_files_list orders known and unknown sessions deterministically", {
+  temp_dir <- tempfile()
+  transcripts_dir <- file.path(temp_dir, "transcripts")
+  dir.create(transcripts_dir, recursive = TRUE)
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+
+  file.create(
+    file.path(transcripts_dir, "zeta.transcript.vtt"),
+    file.path(transcripts_dir, "alpha.transcript.vtt"),
+    file.path(transcripts_dir, "GMT20240612-130000_Recording.transcript.vtt"),
+    file.path(transcripts_dir, "GMT20240612-120000_Recording.transcript.vtt")
+  )
+
+  load_sessions <- function() {
+    load_transcript_files_list(
+      data_folder = temp_dir,
+      transcripts_folder = "transcripts",
+      transcript_files_names_pattern = "[.]transcript[.]vtt$"
+    )
+  }
+
+  expect_warning(
+    first <- load_sessions(),
+    "Recording time could not be parsed for 2 sessions"
+  )
+  expect_warning(
+    second <- load_sessions(),
+    "Recording time could not be parsed for 2 sessions"
+  )
+
+  expect_identical(first, second)
+  expect_equal(
+    first$session_key,
+    c(
+      "GMT20240612-120000_Recording",
+      "GMT20240612-130000_Recording",
+      "alpha",
+      "zeta"
+    )
+  )
+  expect_false(any(is.na(first$recording_start[1:2])))
+  expect_true(all(is.na(first$recording_start[3:4])))
+  expect_true(all(is.na(first$start_time_local[3:4])))
 })
 
 test_that("load_transcript_files_list handles empty folder gracefully", {


### PR DESCRIPTION
## Outcome

Implements the approved T2 session-identity contract: non-Zoom filenames retain
a stable derived session key while unknown recording times remain `NA` instead
of becoming misleading 1970-era timestamps.

Closes #560. Tracks #576 (T2).

## Change class

- [x] Routine
- [ ] Governed — maintainer authorization is linked below
- [ ] Release/external mutation — separate approval is linked below

Authorization/evidence link, if required: the governing attendance contract was
authorized and merged in #578. This PR implements only its bounded T2 internal
session behavior.

## Impact

- Package or user behavior: internal transcript discovery now warns once for
  unknown session times and returns `NA` rather than fabricated epoch values.
- Public API or result schema: no exports change; the internal transcript-list
  table gains the stable `session_key` column required by the approved contract.
- Privacy, disclosure, or data handling: warnings contain counts only, not file
  names, paths, participant identifiers, or transcript text.
- CRAN/release line: targets `develop`; `main` and 0.1.0 remain untouched.

## Behavior

- Transcript, closed-caption, and chat siblings group by one derived key.
- Multiple recordings on the same date remain distinct.
- Known timestamps sort chronologically, with the key as a stable tie-breaker.
- Unknown timestamps sort after known timestamps by stable key.
- `recording_start` and `start_time_local` remain typed `POSIXct` values with
  `NA` for unknown times.
- Repeated runs produce identical results.
- Two files that normalize to the same session key and file type fail with an
  `engager_schema_error` rather than being silently merged.

## Validation

- [x] Targeted tests (session listing and configuration discovery)
- [x] `Rscript scripts/pre-pr-validation.R`
- [x] Generated documentation is committed and drift-free, if applicable — not
  applicable; no roxygen source changed
- [x] Installed-package UAT, if required by the release tranche — not required
  until T3/T5
- [x] Only synthetic fixtures and temporary outputs were used

Exact commands and results:

- `git diff --check` — pass
- `devtools::load_all(...); testthat::test_file(...)` — 29 session-list and 55
  configuration assertions passed
- `Rscript scripts/pre-pr-validation.R` — pass without repository mutation
- Full tests — 0 failures; existing 67 warning-path assertions and 5 skips
- Local `R CMD check --as-cran` — 0 errors, 0 warnings, 2 expected local notes
  for offline/time checks and the development version

## Review disposition

- [x] Actionable automated-review findings are fixed or explicitly declined —
      duplicate session/type collisions now fail explicitly in `df9f7e1`
- [x] All review threads are resolved
- [x] Required hosted checks pass at exact head `df9f7e1`

## Risk and rollback

The main risk is downstream code assuming every recording time is non-missing.
The affected discovery/configuration tests now assert the approved missingness
contract, and hosted checks exercise the package matrix. A squash revert restores
the prior behavior, though that behavior is intentionally misleading and would
reopen #560.

## User-facing release note

Unknown recording times are preserved as missing and ordered deterministically
instead of being represented as fabricated 1970 timestamps.
