### PR TITLE
feat: add privacy-safe attendance reports

### DIFF
--- a/R/analyze_multi_session_attendance.R
+++ b/R/analyze_multi_session_attendance.R
@@ -634,23 +634,18 @@ generate_attendance_report <- function(
     "|---|---|---:|---:|---:|---:|---:|---:|"
   )
 
-  for (i in seq_len(nrow(session_summary))) {
-    row <- session_summary[i, , drop = FALSE]
-    report_content <- c(
-      report_content,
-      sprintf(
-        "| %s | %s | %s | %d | %s | %s | %d | %s |",
-        escape_attendance_report_cell(row$session_id),
-        row$status,
-        if (row$eligible) "yes" else "no",
-        row$roster_size,
-        format_attendance_integer(row$attended_count),
-        format_attendance_integer(row$absent_count),
-        row$unmatched_speaker_count,
-        format_attendance_rate(row$attendance_rate)
-      )
-    )
-  }
+  session_lines <- sprintf(
+    "| %s | %s | %s | %d | %s | %s | %d | %s |",
+    escape_attendance_report_cell(session_summary$session_id),
+    session_summary$status,
+    ifelse(session_summary$eligible, "yes", "no"),
+    session_summary$roster_size,
+    format_attendance_integer(session_summary$attended_count),
+    format_attendance_integer(session_summary$absent_count),
+    session_summary$unmatched_speaker_count,
+    format_attendance_rate(session_summary$attendance_rate)
+  )
+  report_content <- c(report_content, session_lines)
 
   problem_count <- sum(analysis_results$problems$count)
   report_content <- c(
@@ -678,19 +673,14 @@ generate_attendance_report <- function(
       "| Session | Code | Severity | Count |",
       "|---|---|---|---:|"
     )
-    for (i in seq_len(nrow(analysis_results$problems))) {
-      row <- analysis_results$problems[i, , drop = FALSE]
-      report_content <- c(
-        report_content,
-        sprintf(
-          "| %s | %s | %s | %d |",
-          escape_attendance_report_cell(row$session_id),
-          escape_attendance_report_cell(row$code),
-          escape_attendance_report_cell(row$severity),
-          row$count
-        )
-      )
-    }
+    problem_lines <- sprintf(
+      "| %s | %s | %s | %d |",
+      escape_attendance_report_cell(analysis_results$problems$session_id),
+      escape_attendance_report_cell(analysis_results$problems$code),
+      escape_attendance_report_cell(analysis_results$problems$severity),
+      analysis_results$problems$count
+    )
+    report_content <- c(report_content, problem_lines)
   }
 
   if (detail == "participant") {
@@ -713,21 +703,16 @@ generate_attendance_report <- function(
       ),
       "|---|---:|---:|---:|---:|---:|"
     )
-    for (i in seq_len(nrow(transformed))) {
-      row <- transformed[i, , drop = FALSE]
-      report_content <- c(
-        report_content,
-        sprintf(
-          "| %s | %d | %d | %s | %s | %s |",
-          escape_attendance_report_cell(row$student_id),
-          row$eligible_sessions,
-          row$sessions_attended,
-          format_attendance_rate(row$attendance_rate),
-          if (row$meets_threshold) "yes" else "no",
-          if (row$is_one_time_attendee) "yes" else "no"
-        )
-      )
-    }
+    participant_lines <- sprintf(
+      "| %s | %d | %d | %s | %s | %s |",
+      escape_attendance_report_cell(transformed$student_id),
+      transformed$eligible_sessions,
+      transformed$sessions_attended,
+      format_attendance_rate(transformed$attendance_rate),
+      ifelse(transformed$meets_threshold, "yes", "no"),
+      ifelse(transformed$is_one_time_attendee, "yes", "no")
+    )
+    report_content <- c(report_content, participant_lines)
   }
 
   if (!is.null(output_file)) {
@@ -827,15 +812,27 @@ transform_report_identifiers <- function(data, method, salt = NULL) {
 }
 
 format_attendance_rate <- function(value) {
-  if (length(value) != 1L || is.na(value)) return("NA")
-  paste0(
-    formatC(100 * value, format = "f", digits = 1, decimal.mark = "."),
+  if (is.null(value)) return(character())
+  result <- rep("NA", length(value))
+  valid <- !is.na(value)
+  result[valid] <- paste0(
+    formatC(
+      100 * value[valid],
+      format = "f",
+      digits = 1,
+      decimal.mark = "."
+    ),
     "%"
   )
+  result
 }
 
 format_attendance_integer <- function(value) {
-  if (length(value) != 1L || is.na(value)) "NA" else as.character(value)
+  if (is.null(value)) return(character())
+  result <- rep("NA", length(value))
+  valid <- !is.na(value)
+  result[valid] <- as.character(value[valid])
+  result
 }
 
 escape_attendance_report_cell <- function(value) {

--- a/R/analyze_multi_session_attendance.R
+++ b/R/analyze_multi_session_attendance.R
@@ -566,96 +566,281 @@ summary.engager_attendance <- function(object, ...) {
   )
 }
 
-#' Experimental Attendance Report
+#' Generate a Reviewable Attendance Report
 #'
-#' Internal prototype for a possible v0.1.1 reporting workflow. Chart and
-#' threshold semantics are not part of the v0.1.0 public API.
+#' Internal 0.1.1 report engine. Aggregate output is the default and contains
+#' no participant identifiers or transcript text. Participant detail is an
+#' explicit opt-in and requires a supported technical identifier
+#' transformation. These operations do not establish anonymity, legal
+#' compliance, institutional approval, or protection from contextual
+#' disclosure in small cohorts.
 #'
-#' @param analysis_results Results from `analyze_multi_session_attendance()`
-#' @param output_file Optional file path to save the report
-#' @param include_charts Boolean to include charts (default: FALSE)
-#' @return Report content as character vector
+#' @param analysis_results An `engager_attendance` object returned by
+#'   `analyze_multi_session_attendance()`.
+#' @param output_file Optional path for the deterministic Markdown report.
+#' @param detail Either `"aggregate"` or `"participant"`.
+#' @param identifier_method For participant detail, one of `"mask"`, `"hash"`,
+#'   or `"pseudonymize"`.
+#' @param salt Required non-empty salt when `identifier_method = "hash"`.
+#' @return Deterministic Markdown report content as a character vector.
 #' @keywords internal
 generate_attendance_report <- function(
-    analysis_results = NULL,
+    analysis_results,
     output_file = NULL,
-    include_charts = FALSE) {
-  if (!is.list(analysis_results) || !"participation_patterns" %in% names(analysis_results)) {
-    stop("analysis_results must be the output from analyze_multi_session_attendance()")
-  }
+    detail = c("aggregate", "participant"),
+    identifier_method = NULL,
+    salt = NULL) {
+  validate_report_input(analysis_results)
+  detail <- match.arg(detail)
+  validate_report_options(detail, identifier_method, salt)
+  validate_report_output(output_file)
 
-  patterns <- analysis_results$participation_patterns
-  summary <- analysis_results$attendance_summary
+  participant_summary <- analysis_results$participant_summary
+  session_summary <- analysis_results$session_summary
+  metadata <- analysis_results$metadata
+  threshold <- metadata$min_attendance_threshold
 
-  # Generate report content
   report_content <- c(
-    "# Multi-Session Attendance Analysis Report",
+    "# Multi-Session Attendance Report",
     "",
-    paste("**Generated**:", format(Sys.time(), "%Y-%m-%d %H:%M:%S")),
-    paste("**Sessions Analyzed**:", patterns$total_sessions),
-    paste("**Total Participants**:", patterns$total_participants),
+    "## Course summary",
     "",
-    "## Participation Summary",
-    "",
-    paste(
-      "- **Consistent Attendees** (>=", patterns$total_sessions * 0.5,
-      "sessions):", patterns$consistent_attendees
+    sprintf("- Recorded sessions: %d", metadata$eligible_session_count),
+    sprintf("- Eligible participants: %d", metadata$eligible_roster_size),
+    sprintf("- Attendance threshold: %s", format_attendance_rate(threshold)),
+    sprintf(
+      "- Participants meeting threshold: %d",
+      sum(participant_summary$meets_threshold)
     ),
-    paste(
-      "- **Occasional Attendees** (2-",
-      ceiling(patterns$total_sessions * 0.5) - 1,
-      "sessions):", patterns$occasional_attendees
+    sprintf(
+      "- One-time attendees: %d",
+      sum(participant_summary$is_one_time_attendee)
     ),
-    paste("- **One-time Attendees**:", patterns$one_time_attendees),
+    sprintf(
+      "- Participants with zero recorded attendance: %d",
+      sum(participant_summary$sessions_attended == 0L)
+    ),
+    sprintf(
+      "- Mean attendance rate: %s",
+      format_attendance_rate(mean(participant_summary$attendance_rate))
+    ),
     "",
-    "## Attendance Statistics",
+    "## Session summary",
     "",
-    paste("- **Average Attendance Rate**:", patterns$average_attendance_rate, "%"),
-    paste("- **Median Attendance Rate**:", patterns$median_attendance_rate, "%"),
-    paste("- **Attendance Rate Std Dev**:", patterns$attendance_rate_std, "%"),
-    "",
-    "## Technical Privacy Check",
-    "",
-    if (analysis_results$privacy_compliant) {
-      "[PASS] Package masking checks completed"
-    } else {
-      "[FAIL] Package masking checks detected possible identifiers"
-    },
-    ""
+    paste0(
+      "| Session | Status | Eligible | Roster size | Attended | Absent | ",
+      "Unmatched speakers | Attendance rate |"
+    ),
+    "|---|---|---:|---:|---:|---:|---:|---:|"
   )
 
-  # Add attendance matrix if privacy allows
-  if (analysis_results$privacy_compliant) {
+  for (i in seq_len(nrow(session_summary))) {
+    row <- session_summary[i, , drop = FALSE]
     report_content <- c(
       report_content,
-      "## Attendance Matrix",
-      "",
-      "| Participant | Sessions Attended | Attendance Rate |",
-      "|-------------|-------------------|-----------------|"
+      sprintf(
+        "| %s | %s | %s | %d | %s | %s | %d | %s |",
+        escape_attendance_report_cell(row$session_id),
+        row$status,
+        if (row$eligible) "yes" else "no",
+        row$roster_size,
+        format_attendance_integer(row$attended_count),
+        format_attendance_integer(row$absent_count),
+        row$unmatched_speaker_count,
+        format_attendance_rate(row$attendance_rate)
+      )
     )
+  }
 
-    for (i in seq_len(min(10, nrow(summary)))) { # Limit to first 10 for report
-      row <- summary[i, ]
+  problem_count <- sum(analysis_results$problems$count)
+  report_content <- c(
+    report_content,
+    "",
+    "## Review notes",
+    "",
+    sprintf("- Recorded problem count: %d", problem_count),
+    paste0(
+      "- This report uses technical privacy-supporting transformations and ",
+      "does not determine anonymity, legal compliance, or institutional approval."
+    ),
+    paste0(
+      "- Small cohorts and contextual details may still permit identification; ",
+      "review disclosure risk before sharing."
+    )
+  )
+
+  if (nrow(analysis_results$problems) > 0L) {
+    report_content <- c(
+      report_content,
+      "",
+      "### Structured problems",
+      "",
+      "| Session | Code | Severity | Count |",
+      "|---|---|---|---:|"
+    )
+    for (i in seq_len(nrow(analysis_results$problems))) {
+      row <- analysis_results$problems[i, , drop = FALSE]
       report_content <- c(
         report_content,
         sprintf(
-          "| %s | %d | %.1f%% |",
-          row$participant,
-          row$total_sessions,
-          row$attendance_rate
+          "| %s | %s | %s | %d |",
+          escape_attendance_report_cell(row$session_id),
+          escape_attendance_report_cell(row$code),
+          escape_attendance_report_cell(row$severity),
+          row$count
         )
       )
     }
+  }
 
-    if (nrow(summary) > 10) {
-      report_content <- c(report_content, "| ... | ... | ... |")
+  if (detail == "participant") {
+    transformed <- transform_report_identifiers(
+      participant_summary,
+      identifier_method,
+      salt
+    )
+    report_content <- c(
+      report_content,
+      "",
+      sprintf(
+        "## Participant detail (%s identifiers)",
+        identifier_method
+      ),
+      "",
+      paste0(
+        "| Participant | Eligible sessions | Sessions attended | ",
+        "Attendance rate | Meets threshold | One-time attendee |"
+      ),
+      "|---|---:|---:|---:|---:|---:|"
+    )
+    for (i in seq_len(nrow(transformed))) {
+      row <- transformed[i, , drop = FALSE]
+      report_content <- c(
+        report_content,
+        sprintf(
+          "| %s | %d | %d | %s | %s | %s |",
+          escape_attendance_report_cell(row$student_id),
+          row$eligible_sessions,
+          row$sessions_attended,
+          format_attendance_rate(row$attendance_rate),
+          if (row$meets_threshold) "yes" else "no",
+          if (row$is_one_time_attendee) "yes" else "no"
+        )
+      )
     }
   }
 
-  # Save report if output file specified
   if (!is.null(output_file)) {
-    writeLines(report_content, output_file)
+    writeLines(report_content, output_file, useBytes = TRUE)
+  }
+  report_content
+}
+
+validate_report_input <- function(analysis_results) {
+  valid <- inherits(analysis_results, "engager_attendance") &&
+    is.list(analysis_results$metadata) &&
+    identical(
+      analysis_results$metadata$schema_version,
+      "engager_attendance_v1"
+    )
+  if (!valid) {
+    rlang::abort(
+      message = paste0(
+        "analysis_results must be an engager_attendance object with schema ",
+        "engager_attendance_v1."
+      ),
+      class = "engager_input_error"
+    )
+  }
+  invisible(analysis_results)
+}
+
+validate_report_options <- function(detail, identifier_method, salt) {
+  if (detail == "aggregate") {
+    if (!is.null(identifier_method) || !is.null(salt)) {
+      rlang::abort(
+        message = paste0(
+          "identifier_method and salt are only supported when ",
+          "detail = \"participant\"."
+        ),
+        class = "engager_input_error"
+      )
+    }
+    return(invisible(NULL))
   }
 
-  return(report_content)
+  valid_method <- is.character(identifier_method) &&
+    length(identifier_method) == 1L && !is.na(identifier_method) &&
+    identifier_method %in% c("mask", "hash", "pseudonymize")
+  if (!valid_method) {
+    rlang::abort(
+      message = paste0(
+        "Participant detail requires identifier_method = \"mask\", ",
+        "\"hash\", or \"pseudonymize\"."
+      ),
+      class = "engager_input_error"
+    )
+  }
+  if (identifier_method == "hash") {
+    valid_salt <- is.character(salt) && length(salt) == 1L &&
+      !is.na(salt) && nzchar(trimws(salt))
+    if (!valid_salt) {
+      rlang::abort(
+        message = "Hash participant detail requires one explicit non-empty salt.",
+        class = "engager_input_error"
+      )
+    }
+  } else if (!is.null(salt)) {
+    rlang::abort(
+      message = "salt is supported only when identifier_method = \"hash\".",
+      class = "engager_input_error"
+    )
+  }
+  invisible(NULL)
+}
+
+validate_report_output <- function(output_file) {
+  if (is.null(output_file)) return(invisible(NULL))
+  valid <- is.character(output_file) && length(output_file) == 1L &&
+    !is.na(output_file) && nzchar(trimws(output_file))
+  if (!valid) {
+    rlang::abort(
+      message = "output_file must be one non-empty character path.",
+      class = "engager_input_error"
+    )
+  }
+  if (!dir.exists(dirname(output_file))) {
+    rlang::abort(
+      message = "The output_file parent directory must already exist.",
+      class = "engager_input_error"
+    )
+  }
+  invisible(output_file)
+}
+
+transform_report_identifiers <- function(data, method, salt = NULL) {
+  anonymize_educational_data(
+    data,
+    method = method,
+    hash_salt = salt
+  )
+}
+
+format_attendance_rate <- function(value) {
+  if (length(value) != 1L || is.na(value)) return("NA")
+  paste0(
+    formatC(100 * value, format = "f", digits = 1, decimal.mark = "."),
+    "%"
+  )
+}
+
+format_attendance_integer <- function(value) {
+  if (length(value) != 1L || is.na(value)) "NA" else as.character(value)
+}
+
+escape_attendance_report_cell <- function(value) {
+  value <- as.character(value)
+  value <- gsub("\r", " ", value, fixed = TRUE)
+  value <- gsub("\n", " ", value, fixed = TRUE)
+  gsub("|", "\\\\|", value, fixed = TRUE)
 }

--- a/man/generate_attendance_report.Rd
+++ b/man/generate_attendance_report.Rd
@@ -2,26 +2,38 @@
 % Please edit documentation in R/analyze_multi_session_attendance.R
 \name{generate_attendance_report}
 \alias{generate_attendance_report}
-\title{Experimental Attendance Report}
+\title{Generate a Reviewable Attendance Report}
 \usage{
 generate_attendance_report(
-  analysis_results = NULL,
+  analysis_results,
   output_file = NULL,
-  include_charts = FALSE
+  detail = c("aggregate", "participant"),
+  identifier_method = NULL,
+  salt = NULL
 )
 }
 \arguments{
-\item{analysis_results}{Results from \code{analyze_multi_session_attendance()}}
+\item{analysis_results}{An \code{engager_attendance} object returned by
+\code{analyze_multi_session_attendance()}.}
 
-\item{output_file}{Optional file path to save the report}
+\item{output_file}{Optional path for the deterministic Markdown report.}
 
-\item{include_charts}{Boolean to include charts (default: FALSE)}
+\item{detail}{Either \code{"aggregate"} or \code{"participant"}.}
+
+\item{identifier_method}{For participant detail, one of \code{"mask"}, \code{"hash"},
+or \code{"pseudonymize"}.}
+
+\item{salt}{Required non-empty salt when \code{identifier_method = "hash"}.}
 }
 \value{
-Report content as character vector
+Deterministic Markdown report content as a character vector.
 }
 \description{
-Internal prototype for a possible v0.1.1 reporting workflow. Chart and
-threshold semantics are not part of the v0.1.0 public API.
+Internal 0.1.1 report engine. Aggregate output is the default and contains
+no participant identifiers or transcript text. Participant detail is an
+explicit opt-in and requires a supported technical identifier
+transformation. These operations do not establish anonymity, legal
+compliance, institutional approval, or protection from contextual
+disclosure in small cohorts.
 }
 \keyword{internal}

--- a/tests/testthat/test-analyze_multi_session_attendance.R
+++ b/tests/testthat/test-analyze_multi_session_attendance.R
@@ -275,29 +275,3 @@ test_that("attendance print and summary disclose aggregate counts only", {
   expect_identical(summarized$eligible_roster_size, 5L)
   expect_false(grepl("Ada Rowan|student-001|Guest Nova", disclosure_text))
 })
-
-test_that("experimental report remains internal pending T4", {
-  mock_results <- list(
-    attendance_summary = data.frame(
-      participant = "Student_001",
-      total_sessions = 2L,
-      attendance_rate = 100,
-      stringsAsFactors = FALSE
-    ),
-    participation_patterns = list(
-      total_participants = 1L,
-      total_sessions = 2L,
-      consistent_attendees = 1L,
-      occasional_attendees = 0L,
-      one_time_attendees = 0L,
-      average_attendance_rate = 100,
-      median_attendance_rate = 100,
-      attendance_rate_std = 0
-    ),
-    privacy_compliant = TRUE
-  )
-
-  report <- generate_attendance_report(mock_results)
-  expect_true(any(grepl("Multi-Session Attendance Analysis Report", report)))
-  expect_false("generate_attendance_report" %in% getNamespaceExports("engager"))
-})

--- a/tests/testthat/test-generate_attendance_report.R
+++ b/tests/testthat/test-generate_attendance_report.R
@@ -1,0 +1,208 @@
+report_fixture_path <- function(file) {
+  system.file("extdata", "attendance-contract", file, package = "engager")
+}
+
+report_fixture_roster <- function() {
+  readr::read_csv(
+    report_fixture_path("roster.csv"),
+    show_col_types = FALSE,
+    na = c("", "NA")
+  )
+}
+
+report_fixture_sessions <- function() {
+  tibble::tibble(
+    session_id = sprintf("session-%02d", 1:4),
+    transcript_file = c(
+      report_fixture_path("session-01.vtt"),
+      report_fixture_path("session-02.vtt"),
+      report_fixture_path("session-03.vtt"),
+      NA_character_
+    ),
+    status = c(rep("recorded", 3), "cancelled"),
+    session_at = as.POSIXct(
+      c(
+        "2026-01-10 09:00:00",
+        "2026-01-17 09:00:00",
+        "2026-01-24 09:00:00",
+        "2026-01-31 09:00:00"
+      ),
+      tz = "UTC"
+    )
+  )
+}
+
+report_fixture_analysis <- function(threshold = 2 / 3) {
+  suppressWarnings(analyze_multi_session_attendance(
+    report_fixture_sessions(),
+    report_fixture_roster(),
+    min_attendance_threshold = threshold
+  ))
+}
+
+test_that("aggregate attendance report is deterministic and identifier-free", {
+  analysis <- report_fixture_analysis()
+  first <- generate_attendance_report(analysis)
+  second <- generate_attendance_report(analysis)
+  report_text <- paste(first, collapse = "\n")
+
+  expect_identical(first, second)
+  expect_match(report_text, "Attendance threshold: 66.7%", fixed = TRUE)
+  expect_match(report_text, "Recorded sessions: 3", fixed = TRUE)
+  expect_match(report_text, "Eligible participants: 5", fixed = TRUE)
+  expect_match(report_text, "Participants meeting threshold: 3", fixed = TRUE)
+  expect_match(report_text, "Participants with zero recorded attendance: 1", fixed = TRUE)
+  expect_match(report_text, "session-04 | cancelled", fixed = TRUE)
+  expect_match(report_text, "Recorded problem count: 1", fixed = TRUE)
+  expect_match(report_text, "unmatched_speaker", fixed = TRUE)
+  expect_match(report_text, "does not determine anonymity", fixed = TRUE)
+  expect_match(report_text, "Small cohorts", fixed = TRUE)
+  expect_false(grepl("## Participant detail", report_text, fixed = TRUE))
+  expect_false(grepl("Generated", report_text, fixed = TRUE))
+
+  forbidden <- c(
+    report_fixture_roster()$student_id,
+    report_fixture_roster()$preferred_name,
+    "Guest Nova",
+    "Welcome back",
+    report_fixture_path("session-01.vtt")
+  )
+  expect_false(any(vapply(forbidden, grepl, logical(1), x = report_text, fixed = TRUE)))
+
+  output <- tempfile(fileext = ".md")
+  on.exit(unlink(output), add = TRUE)
+  written <- generate_attendance_report(analysis, output_file = output)
+  expect_identical(readLines(output, warn = FALSE), written)
+})
+
+test_that("participant report requires and applies a supported transformation", {
+  analysis <- report_fixture_analysis()
+  salt <- "synthetic-report-salt"
+
+  masked <- generate_attendance_report(
+    analysis,
+    detail = "participant",
+    identifier_method = "mask"
+  )
+  pseudonymized <- generate_attendance_report(
+    analysis,
+    detail = "participant",
+    identifier_method = "pseudonymize"
+  )
+  hashed <- generate_attendance_report(
+    analysis,
+    detail = "participant",
+    identifier_method = "hash",
+    salt = salt
+  )
+
+  masked_text <- paste(masked, collapse = "\n")
+  pseudonymized_text <- paste(pseudonymized, collapse = "\n")
+  hashed_text <- paste(hashed, collapse = "\n")
+  expected_hash <- substr(digest::digest(
+    paste0("student-001", salt),
+    algo = "sha256",
+    serialize = FALSE
+  ), 1, 8)
+
+  expect_match(masked_text, "Student_1", fixed = TRUE)
+  expect_match(pseudonymized_text, "PSEUDO_1", fixed = TRUE)
+  expect_match(hashed_text, expected_hash, fixed = TRUE)
+  for (text in c(masked_text, pseudonymized_text, hashed_text)) {
+    expect_false(grepl("student-001|Ada Rowan|Guest Nova", text))
+    expect_match(text, "Attendance threshold: 66.7%", fixed = TRUE)
+  }
+})
+
+test_that("participant report rejects raw or ambiguous detail requests", {
+  analysis <- report_fixture_analysis()
+
+  expect_error(
+    generate_attendance_report(analysis, detail = "participant"),
+    "requires identifier_method",
+    class = "engager_input_error"
+  )
+  expect_error(
+    generate_attendance_report(
+      analysis,
+      detail = "participant",
+      identifier_method = "hash"
+    ),
+    "explicit non-empty salt",
+    class = "engager_input_error"
+  )
+  expect_error(
+    generate_attendance_report(
+      analysis,
+      detail = "participant",
+      identifier_method = "mask",
+      salt = "unused"
+    ),
+    "supported only when identifier_method",
+    class = "engager_input_error"
+  )
+  expect_error(
+    generate_attendance_report(
+      analysis,
+      identifier_method = "mask"
+    ),
+    "only supported when detail",
+    class = "engager_input_error"
+  )
+  expect_error(
+    generate_attendance_report(analysis, output_file = " "),
+    "one non-empty character path",
+    class = "engager_input_error"
+  )
+  expect_error(
+    generate_attendance_report(
+      analysis,
+      output_file = file.path(tempfile(), "report.md")
+    ),
+    "parent directory must already exist",
+    class = "engager_input_error"
+  )
+})
+
+test_that("attendance identifier transformation preserves missing and blank values", {
+  data <- tibble::tibble(
+    student_id = c("student-001", NA_character_, "", "  "),
+    sessions_attended = c(1L, 0L, 0L, 0L)
+  )
+
+  for (method in c("mask", "pseudonymize")) {
+    transformed <- transform_report_identifiers(data, method)
+    expect_true(is.na(transformed$student_id[2]))
+    expect_identical(transformed$student_id[3], "")
+    expect_identical(transformed$student_id[4], "  ")
+  }
+  hashed <- transform_report_identifiers(data, "hash", "synthetic-salt")
+  expect_true(is.na(hashed$student_id[2]))
+  expect_identical(hashed$student_id[3], "")
+  expect_identical(hashed$student_id[4], "  ")
+})
+
+test_that("attendance report validates schema and escapes Markdown cells", {
+  expect_error(
+    generate_attendance_report(list()),
+    "engager_attendance_v1",
+    class = "engager_input_error"
+  )
+
+  analysis <- report_fixture_analysis()
+  analysis$metadata$schema_version <- "future_schema"
+  expect_error(
+    generate_attendance_report(analysis),
+    "engager_attendance_v1",
+    class = "engager_input_error"
+  )
+
+  analysis <- report_fixture_analysis()
+  analysis$session_summary$session_id[1] <- "session|one\nreview"
+  report <- paste(generate_attendance_report(analysis), collapse = "\n")
+  expect_match(report, "session\\\\|one review", fixed = TRUE)
+})
+
+test_that("attendance report remains internal until T5", {
+  expect_false("generate_attendance_report" %in% getNamespaceExports("engager"))
+})


### PR DESCRIPTION
## Outcome

Implements the approved T4 attendance report contract: deterministic aggregate
Markdown by default, with no raw participant identifiers or transcript text,
and explicit participant detail only after a supported identifier
transformation.

Tracks #576 (T4). Contract authority: #578.

## Change class

- [x] Routine implementation of an already approved governed privacy contract
- [ ] Governed contract or public API change
- [ ] Release/external mutation

Authorization/evidence: #578 approved aggregate-default reporting, explicit
transformed participant opt-in, threshold propagation, deterministic content,
and technical privacy language. This PR implements those semantics without
exporting the function; public graduation remains T5.

## Impact

- Default behavior: aggregate course/session/problem counts only.
- Participant detail: requires `mask`, `hash`, or `pseudonymize`; raw detail is
  unavailable and hash mode requires an explicit non-empty salt.
- Disclosure surfaces: problem messages, roster IDs, names, transcript text,
  source paths, input fingerprints, salts, and generated timestamps are absent
  from aggregate content.
- Determinism: repeated calls on the same analysis object return identical
  report content; generated time is not embedded.
- Privacy language: reports explicitly preserve small-cohort/contextual review
  responsibilities and make no anonymity, legal, or institutional claim.
- Public API and release isolation: exports remain unchanged; the PR targets
  `develop`, leaving `main` and 0.1.0 untouched.

## Behavior

- Propagates the analysis threshold instead of substituting `0.5`.
- Summarizes cancellations, session denominators, unmatched counts, and stable
  structured problem codes without free text.
- Escapes Markdown cell boundaries and embedded line breaks.
- Validates report schema, detail/method/salt combinations, and output paths.
- Writes byte-stable Markdown when `output_file` is supplied.
- Preserves missing and blank identifiers through all three transformations.

## Validation

- [x] Aggregate raw-identifier and transcript-text absence assertions
- [x] Mask, hash, and pseudonymize participant-detail assertions
- [x] Threshold propagation and deterministic-content assertions
- [x] Missing/blank, Markdown escaping, invalid schema, and output-path tests
- [x] `Rscript scripts/pre-pr-validation.R`
- [x] Generated roxygen documentation is committed
- [x] Only synthetic fixtures and temporary outputs were used

Exact commands and results at `83464b4`:

- `git diff --check` — pass
- Targeted report tests — 43 assertions passed
- Targeted attendance-engine tests — 41 assertions passed
- `Rscript scripts/pre-pr-validation.R` — pass without repository mutation
- Full tests — 0 failures; unchanged 67 warning-path assertions and 5 skips
- Local `R CMD check --as-cran` — 0 errors, 0 warnings, 2 expected local notes
  for offline/time checks and the development version
- Local lint — no new findings; only the contract-mandated long attendance
  engine name remains

## Review disposition

- [x] Actionable automated-review findings are fixed or explicitly declined
- [x] All review threads are resolved
- [x] Required hosted checks pass at this exact head

Gemini's four table-generation and formatter findings were implemented by
vectorizing the report construction in `83464b4`. Targeted tests and the full
canonical validator were rerun after that change. All exact-head hosted checks,
including the Windows, macOS, and Ubuntu R CMD check matrix, passed.

## Risk and rollback

The primary risk is accidental disclosure through aggregate output or an
implicit raw-detail path. Tests scan aggregate and transformed outputs for all
synthetic roster IDs, names, transcript text, and source paths; invalid detail
requests fail before content is generated. A squash revert restores the
internal prototype without changing the public 0.1.0 API.

## User-facing release note

Deferred to T5, when the reviewed attendance analysis and reporting workflow
graduates together with installed-package UAT and public documentation.
