### PR TITLE
docs: record CRAN acceptance closeout evidence

### DIFF
--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -2,8 +2,9 @@
 
 Status: product and release planning source of truth.
 
-Last release-state reconciliation: 2026-07-22 against stable `main` at
-`6214c0316d39154140bdba064266119007bff41a` and 35 current exports. The
+Last release-state reconciliation: 2026-07-30 against the public CRAN 0.1.0
+package, stable `main` at
+`4b72bb0cefeb1dfa4fe21efb87a87a5c2610fdfa`, and 35 current exports. The
 feature/backlog baseline remains the 2026-07-15 review of the historical
 pre-scope-reduction API and 122 then-open GitHub issues. The existing
 `project-docs/backlog-normalization` snapshot contains 128 issues and must be
@@ -45,9 +46,9 @@ turning participation measurements into unsupported judgments about students.
 
 ### 0.1.0 — Focused transcript-analysis foundation
 
-Status: CRAN-requested documentation and write-safety remediation is validated
-locally and on R-devel win-builder; awaiting maintainer-controlled
-resubmission.
+Status: published on CRAN on 2026-07-30. Public source reconciliation and
+installed-package UAT pass; the 48-hour CRAN check-matrix review, annotated
+tag, GitHub release, and issue #4 closure remain pending.
 
 Supported product:
 

--- a/project-docs/communications/inbox/2026-07-30_konstanze-lauseker_cran-publication.md
+++ b/project-docs/communications/inbox/2026-07-30_konstanze-lauseker_cran-publication.md
@@ -1,0 +1,106 @@
+# Raw incoming email — CRAN publication confirmation
+
+Source: pasted by the maintainer into the project orchestration task on
+2026-07-30.
+
+```text
+From: Konstanze Lauseker <konstanze.lauseker@wu.ac.at>
+Sent: 10:19 AM (7 hours before intake)
+To: CRAN, CRAN, Conor Healy
+Subject: Re: CRAN Submission engager 0.1.0
+
+Thanks,
+on its way to CRAN.
+
+Best,
+Konstanze Lauseker (she/her)
+
+On 22/07/2026 09:54, CRAN Package Submission Form via CRAN-submissions wrote:
+> External Sender
+>
+> [This was generated from CRAN.R-project.org/submit.html]
+>
+> The following package was uploaded to CRAN:
+> ===========================================
+>
+> Package Information:
+> Package: engager
+> Version: 0.1.0
+> Title: Analyze Student Engagement from 'WebVTT' Transcripts
+> Author(s): Conor Healy [aut, cre]
+> Maintainer: Conor Healy <conorhealy@berkeley.edu>
+> Depends: R (>= 4.1.0)
+> Suggests: testthat (>= 3.0.0), withr, covr, knitr, rmarkdown, purrr,
+>   microbenchmark, gridExtra
+> Description: Analyzes participation in course-session transcripts stored
+>   in the 'WebVTT' format <https://www.w3.org/TR/webvtt1/>,
+>   including transcripts exported by 'Zoom' and similar
+>   videoconferencing platforms. Provides tools to load and
+>   process transcripts, calculate speaker-level engagement
+>   metrics, create privacy-supporting plots and exports, and
+>   perform reviewable exact name matching against course
+>   rosters. Structured-field masking and technical
+>   privacy-review helpers support local review but do not
+>   determine legal or institutional compliance.
+> License: MIT + file LICENSE
+> Imports: digest, dplyr, ggplot2, hms, openssl, jsonlite, lubridate,
+>   magrittr, tidyr, readr, rlang, stringi, stringr, tibble
+>
+> The maintainer confirms that he or she has read and agrees to the CRAN
+> policies.
+>
+> Submitter's comment: Resubmission addressing CRAN reviewer feedback.
+>
+> Added meaningful value documentation for all exported functions and
+> completed argument documentation. Removed examples for unexported
+> functions. Replaced dontrun and commented examples with runnable examples
+> using synthetic data and temporary destinations.
+>
+> Analysis workflows are now read-only by default. File-writing functions
+> require an explicit caller-selected destination.
+>
+> R-devel win-builder completed with 0 errors, 0 warnings, and 1
+> incoming-feasibility NOTE: New submission plus “reviewable” as a possible
+> misspelling. “reviewable” is intentional.
+>
+> Original DESCRIPTION summary:
+> Package: engager
+> Type: Package
+> Title: Analyze Student Engagement from 'WebVTT' Transcripts
+> Version: 0.1.0
+> Authors@R: person(given = "Conor",
+>                  family = "Healy",
+>                  role = c("aut", "cre"),
+>                  email = "conorhealy@berkeley.edu")
+> Description: Analyzes participation in course-session transcripts stored in
+>     the 'WebVTT' format <https://www.w3.org/TR/webvtt1/>, including transcripts
+>     exported by 'Zoom' and similar videoconferencing platforms. Provides tools
+>     to load and process transcripts, calculate speaker-level engagement metrics,
+>     create privacy-supporting plots and exports, and perform reviewable exact
+>     name matching against course rosters. Structured-field masking and technical
+>     privacy-review helpers support local review but do not determine legal or
+>     institutional compliance.
+> License: MIT + file LICENSE
+> Depends: R (>= 4.1.0)
+> Language: en-US
+> Encoding: UTF-8
+> Roxygen: list(markdown = TRUE)
+> RoxygenNote: 7.3.3
+> Imports: digest, dplyr, ggplot2, hms, openssl, jsonlite, lubridate,
+>         magrittr, tidyr, readr, rlang, stringi, stringr, tibble
+> Suggests: testthat (>= 3.0.0), withr, covr, knitr, rmarkdown, purrr,
+>         microbenchmark, gridExtra
+> VignetteBuilder: knitr
+> Config/testthat/edition: 3
+> URL: https://github.com/revgizmo/engager,
+>      https://revgizmo.github.io/engager/
+> BugReports: https://github.com/revgizmo/engager/issues
+> NeedsCompilation: no
+> Packaged: 2026-07-21 22:38:36 UTC; piper
+> Author: Conor Healy [aut, cre]
+> Maintainer: Conor Healy <conorhealy@berkeley.edu>
+```
+
+The quoted dependency and description text is preserved for provenance. The
+public CRAN package page and published source archive are the authoritative
+publication records.

--- a/project-docs/communications/intake/2026-07-30_konstanze-lauseker_cran-publication_intake.md
+++ b/project-docs/communications/intake/2026-07-30_konstanze-lauseker_cran-publication_intake.md
@@ -1,0 +1,61 @@
+# Incoming email intake — `engager` 0.1.0 CRAN publication
+
+## Source
+
+- Sender: Konstanze Lauseker, CRAN
+- Received: 2026-07-30
+- Raw record:
+  [inbox/2026-07-30_konstanze-lauseker_cran-publication.md](../inbox/2026-07-30_konstanze-lauseker_cran-publication.md)
+- Release ledger: [issue #4](https://github.com/revgizmo/engager/issues/4)
+
+## Classification
+
+Release acceptance and publication event. This changes the authoritative
+0.1.0 state from CRAN review to public availability.
+
+## Verified interpretation
+
+The reviewer message says the package is “on its way to CRAN.” Independent
+verification on 2026-07-30 established that:
+
+- the public CRAN package page is live;
+- version `0.1.0` is published with date 2026-07-30;
+- the public source archive is downloadable;
+- the early CRAN check matrix reports six `OK` results and no failures;
+- macOS binaries are available while Windows binaries are still pending;
+- the published archive differs from the submitted archive only through CRAN
+  metadata normalization and its generated `MD5` manifest;
+- installed-package UAT from the published source archive passes using bundled
+  synthetic fixtures.
+
+## Action items
+
+| Owner | Target | Action | Status | Source |
+|---|---|---|---|---|
+| Orchestrator | 2026-07-30 | Reconcile public page, source archive, checksums, extracted contents, and source commit | Complete | CRAN page/source plus this email |
+| Orchestrator | 2026-07-30 | Run isolated installed-package UAT from the published source archive | Complete — PASS | `run_uat_course_workflow.R` |
+| Orchestrator | 2026-07-30 | Update draft PR #584 with final acceptance evidence and current release gates | In progress | This intake |
+| Orchestrator | 2026-07-30 | Post a non-closing publication/UAT update to issue #4 after the updated PR is published | Pending | Issue #4 ledger policy |
+| Maintainer/orchestrator | On or after 2026-08-01 10:20 PDT | Refresh the CRAN matrix after 48 hours and inspect every reported platform | Pending | 0.1.1 release plan |
+| Maintainer | After matrix review | Separately authorize annotated `v0.1.0` tag at `6214c031...` | Pending approval | `CONTRIBUTING.md` |
+| Maintainer | After tag verification | Separately authorize GitHub release publication | Pending approval | `CONTRIBUTING.md` |
+| Maintainer | After release verification | Separately authorize issue #4 closure | Pending approval | `CONTRIBUTING.md` |
+| Development lane | Before rebuilding 0.1.1 | Forward-port the CRAN documentation/write-safety remediation to `develop`, including issue #438 path validation | Pending separate tranche | 0.1.1 release plan |
+
+## Decisions and boundaries
+
+- The published CRAN checksum and submitted checksum are both retained; byte
+  inequality is explained rather than normalized away.
+- The accepted Git tag target remains exact package-source commit
+  `6214c0316d39154140bdba064266119007bff41a`.
+- The later evidence commit is not the tag target.
+- No real or private course data is used for validation.
+- Publication does not authorize a tag, GitHub release, issue closure,
+  `develop` promotion, or 0.1.2 implementation.
+
+## Open gates
+
+- The CRAN check matrix is still populating; the six observed results are all
+  `OK`, but they are not yet the 48-hour final snapshot.
+- Windows binary availability is pending. This is not a source-package blocker.
+- Tag, release, and ledger closure require separate explicit approvals.

--- a/project-docs/release/CRAN_VALIDATION_REPORT.md
+++ b/project-docs/release/CRAN_VALIDATION_REPORT.md
@@ -1,15 +1,31 @@
 # CRAN Validation Report
 
-Generated: 2026-07-22
+Generated: 2026-07-30
 
 ## Decision
 
-**GO for maintainer-controlled manual CRAN resubmission after evidence review.**
+**PUBLISHED — acceptance verification passes; final release closeout pending.**
 
-The documentation and write-safety remediation requested by CRAN passes the
-package-side release gates. Issue #4 updates, CRAN resubmission, acceptance
-closeout, tagging, and release publication remain separately authorized owner
-actions.
+CRAN published `engager` 0.1.0 on 2026-07-30. The public package identity,
+source archive, accepted source commit, and installed workflow are reconciled.
+Wait for the 48-hour CRAN check matrix before requesting the separately
+authorized tag, GitHub release, and issue #4 closure.
+
+## Public CRAN Evidence
+
+- Package page: <https://cran.r-project.org/package=engager>
+- Published source:
+  <https://cran.r-project.org/src/contrib/engager_0.1.0.tar.gz>
+- Publication date: 2026-07-30
+- Published SHA-256:
+  `0051326ad8e0d648969a56b7d374ba9bb4560ffe0f380e201ec6d07ac860468b`
+- Submitted SHA-256:
+  `21e6ecddeed86dad177708d7b7f3bf1df79059f769dedc0e0439e995e2fa5e74`
+- Archive difference: CRAN-normalized `DESCRIPTION` metadata plus generated
+  `MD5`; no R code, documentation, test, vignette, fixture, or other package
+  content difference.
+- Published-tarball installed UAT: PASS on R 4.5.3,
+  `aarch64-apple-darwin20`.
 
 ## Final Remediation Artifact
 
@@ -54,12 +70,12 @@ actions.
 
 ## Remaining Gates
 
-1. Review and merge the evidence-only PR; it must not change any file included
-   in the frozen tarball.
-2. Under separate approval, post the final remediation disposition to issue #4.
-3. The maintainer manually resubmits the exact SHA-verified tarball to CRAN and
-   confirms the submission email.
-4. Preserve any reviewer wording and address only requested failures in a
-   bounded remediation branch.
-5. Keep issue #4 open and do not tag or publish a GitHub release until CRAN
-   acceptance and separate approval.
+1. Refresh the CRAN check matrix on or after 2026-08-01 10:20 PDT and inspect
+   every reported platform; the initial six results are all `OK`.
+2. Record the final publication/check/UAT evidence in issue #4 without closing
+   it.
+3. Obtain separate approval for the annotated `v0.1.0` tag at exact source
+   commit `6214c0316d39154140bdba064266119007bff41a`.
+4. Obtain separate approval for the GitHub release, then for issue #4 closure.
+5. Forward-port the CRAN documentation/write-safety remediation to `develop`
+   before rebuilding the 0.1.1 candidate.

--- a/project-docs/release/V0_1_0_ACCEPTANCE_CLOSEOUT.md
+++ b/project-docs/release/V0_1_0_ACCEPTANCE_CLOSEOUT.md
@@ -1,0 +1,212 @@
+# `engager` 0.1.0 CRAN Acceptance Closeout
+
+Status: CRAN publication verified; installed-package UAT passed; release
+mutations remain pending.
+
+Last reconciled: 2026-07-30 against the public CRAN package page, published
+source tarball, current CRAN check matrix, `origin/main`, and issue #4.
+
+## Decision
+
+`engager` 0.1.0 is publicly available from CRAN. The package identity,
+published archive contents, accepted source commit, and installed workflow are
+reconciled. Do not close the release ledger yet: wait at least 48 hours from
+publication for the CRAN check matrix to populate, then inspect every reported
+platform before requesting the final tag, GitHub release, and issue-close
+approvals.
+
+This packet does not authorize or perform any release mutation.
+
+## Accepted release identity
+
+| Item | Verified value |
+|---|---|
+| Package | `engager` |
+| Version | `0.1.0` |
+| Publication date | 2026-07-30 |
+| Public page | <https://cran.r-project.org/package=engager> |
+| Public source | <https://cran.r-project.org/src/contrib/engager_0.1.0.tar.gz> |
+| CRAN DOI | <https://doi.org/10.32614/CRAN.package.engager> |
+| Submitted source SHA-256 | `21e6ecddeed86dad177708d7b7f3bf1df79059f769dedc0e0439e995e2fa5e74` |
+| Published source SHA-256 | `0051326ad8e0d648969a56b7d374ba9bb4560ffe0f380e201ec6d07ac860468b` |
+| Accepted package-source commit | `6214c0316d39154140bdba064266119007bff41a` |
+| Main evidence commit | `4b72bb0cefeb1dfa4fe21efb87a87a5c2610fdfa` |
+| Package remediation PR | [#587](https://github.com/revgizmo/engager/pull/587) |
+| Evidence PR | [#588](https://github.com/revgizmo/engager/pull/588) |
+| CRAN ledger | [#4](https://github.com/revgizmo/engager/issues/4) |
+
+The submitted artifact remains at:
+
+`/Users/piper/Downloads/engager-cran-0.1.0-remediation-6214c03/engager_0.1.0.tar.gz`
+
+## Gate A — public publication: PASS
+
+The public package page and source tarball resolve and report version `0.1.0`,
+the accepted single-quoted `WebVTT` title, Conor Healy as maintainer, and
+publication date 2026-07-30.
+
+The published and submitted archive checksums differ because CRAN repackaged
+standard metadata. Extracted recursive comparison found no difference in R
+code, documentation, tests, vignettes, fixtures, or other package content.
+Differences were limited to:
+
+- removal of the build-only `Roxygen: list(markdown = TRUE)` field;
+- addition of `Repository: CRAN`;
+- addition of `Date/Publication: 2026-07-30 17:20:16 UTC`;
+- addition of CRAN's generated `MD5` manifest.
+
+The published checksum is authoritative for the CRAN-hosted archive. The
+submitted checksum remains the provenance record for the maintainer-uploaded
+artifact.
+
+## Gate B — installed published-package UAT: PASS
+
+Command:
+
+```sh
+Rscript project-docs/release/run_uat_course_workflow.R \
+  /private/tmp/engager_0.1.0-cran-published.tar.gz \
+  /private/tmp/engager-cran-published-uat-20260730-v1
+```
+
+Evidence:
+
+- installed package version: `0.1.0`;
+- R: R 4.5.3 (2026-03-11);
+- platform: `aarch64-apple-darwin20`;
+- installed namespace: exact 35-function supported export allowlist;
+- guidance: 22 expert functions and 31 onboarding calls checked;
+- fixtures: 3 bundled synthetic sessions and 34 transcript rows;
+- workflows: beginner, composable, summary, plotting, matching, privacy review,
+  and export paths passed;
+- identifier checks: unsafe aggregation rejected, caller-provided hash salt
+  required, missing identifiers preserved, and exported-artifact raw-identifier
+  scan passed;
+- installed vignettes: getting started, essential functions, plotting, and
+  privacy/ethics review discovered;
+- final disposition: `UAT PASS`.
+
+The privacy screen's `passed` field remains `FALSE` because it flags the
+identifier-like in-memory column names `name` and `name_raw`. The exported
+artifact scan passed. This is technical review evidence, not a claim of
+anonymity or legal/institutional compliance.
+
+No real or private course data was used.
+
+## Gate C — accepted source provenance: PASS
+
+Commit `6214c0316d39154140bdba064266119007bff41a` is reachable on `main` and is
+the exact source used to build the submitted remediation artifact. The later
+commit `4b72bb0cefeb1dfa4fe21efb87a87a5c2610fdfa` changes only package-excluded
+release evidence.
+
+The accepted tag target must therefore be `6214c0316d39154140bdba064266119007bff41a`,
+not the later evidence commit and not any 0.1.1 development commit.
+
+## Gate D — CRAN check matrix: IN PROGRESS
+
+At the 2026-07-30 reconciliation, the public matrix reported six results and
+all six were `OK`:
+
+- R-devel Fedora clang;
+- R-devel Fedora gcc;
+- R-release macOS arm64;
+- R-release macOS x86_64;
+- R-oldrel macOS arm64;
+- R-oldrel macOS x86_64.
+
+This is a positive but still early snapshot. Wait until at least
+2026-08-01 10:20 PDT, refresh the matrix, and inspect every reported platform.
+Windows binaries were not yet available at this reconciliation; binary
+availability is not itself a source-package release blocker.
+
+## Gate E — ledger and public release closeout: PENDING APPROVAL
+
+After Gate D passes, post the final verification to issue #4 with:
+
+- CRAN page and publication date;
+- submitted and published checksums and the explained metadata-only difference;
+- accepted source and evidence commits;
+- installed published-tarball UAT result and R/platform;
+- final CRAN check-matrix disposition;
+- tag and GitHub release links when those actions are complete.
+
+Keep issue #4 open until all separately approved release actions finish.
+
+## Separately approved release actions
+
+Perform these sequentially only after the 48-hour CRAN matrix review.
+
+### 1. Create and push the annotated tag
+
+Approval must name `v0.1.0` and source commit
+`6214c0316d39154140bdba064266119007bff41a`.
+
+```sh
+test -z "$(git tag --list v0.1.0)"
+test -z "$(git ls-remote --tags origin refs/tags/v0.1.0)"
+git tag -a v0.1.0 \
+  6214c0316d39154140bdba064266119007bff41a \
+  -m "engager 0.1.0"
+git rev-list -n 1 v0.1.0
+git push origin v0.1.0
+```
+
+### 2. Publish the GitHub release
+
+Use the verified tag. Do not attach a locally rebuilt tarball; CRAN remains the
+authoritative R package distribution.
+
+````markdown
+# engager 0.1.0
+
+First CRAN release of `engager`, an R package for analyzing participation in
+locally held WebVTT course transcripts.
+
+## Included
+
+- WebVTT loading, processing, and consolidation
+- speaker-level engagement metrics and plots
+- privacy-supporting metric exports
+- exact roster matching and unresolved-name review
+- explicit masking, salted hashing, and pseudonymization transformations
+- beginner, composable, and batch transcript workflows
+
+Privacy-supporting transformations and review helpers are technical controls.
+They do not establish anonymity, legal compliance, or institutional approval.
+
+Install from CRAN with:
+
+```r
+install.packages("engager")
+```
+````
+
+### 3. Close issue #4
+
+Issue closure requires separate explicit approval after the tag and GitHub
+release are verified. The closing comment must link the CRAN page, both
+checksum records, installed UAT result, tag, GitHub release, and final check
+matrix.
+
+## Post-closeout unlock
+
+Only after the 0.1.0 tag, GitHub release, and issue #4 closure may the completed
+0.1.1 candidate be considered for governed `develop`-to-`main` promotion. The
+CRAN documentation/write-safety remediation must first be forward-ported to
+`develop` and the 0.1.1 candidate rebuilt and revalidated.
+
+No 0.1.2 implementation is authorized by this closeout.
+
+## Decision table
+
+| Gate | Status | Next action |
+|---|---|---|
+| Public page and source | PASS | Preserve URLs and publication date |
+| Published archive reconciliation | PASS | Record both checksums and CRAN metadata changes |
+| Installed published-package UAT | PASS | Preserve evidence summary |
+| Accepted source provenance | PASS | Tag only `6214c031...` after approval |
+| 48-hour CRAN matrix | IN PROGRESS | Refresh on or after 2026-08-01 10:20 PDT |
+| Annotated tag | PENDING APPROVAL | Create only after matrix review |
+| GitHub release | PENDING APPROVAL | Publish from verified tag |
+| Issue #4 closure | PENDING APPROVAL | Close only after durable evidence is linked |

--- a/project-docs/release/V0_1_1_RELEASE_PLAN.md
+++ b/project-docs/release/V0_1_1_RELEASE_PLAN.md
@@ -1,13 +1,14 @@
 # `engager` 0.1.1 Release Plan
 
-Status: approved planning baseline; isolated 0.1.1 development may proceed on
-protected `develop` while `engager` 0.1.0 remains under CRAN review. Merging
-0.1.1 package content to `main` is governed by the T6 release gates and remains
-strictly blocked until at least the 0.1.0 acceptance closeout is complete.
+Status: approved planning baseline; `engager` 0.1.0 was published on CRAN on
+2026-07-30. Isolated 0.1.1 work may proceed on protected `develop`, but merging
+0.1.1 package content to `main` remains governed by the T6 release gates and is
+blocked until the 0.1.0 acceptance closeout is complete.
 
-Last release-state reconciliation: 2026-07-22 against stable `main` at
-`6214c0316d39154140bdba064266119007bff41a`. The feature/backlog baseline
-remains the 2026-07-15 review.
+Last release-state reconciliation: 2026-07-30 against the public CRAN package,
+stable `main` at `4b72bb0cefeb1dfa4fe21efb87a87a5c2610fdfa`, and the accepted
+package-source commit `6214c0316d39154140bdba064266119007bff41a`. The
+feature/backlog baseline remains the 2026-07-15 review.
 
 ## Release thesis
 
@@ -43,19 +44,20 @@ The submitted 0.1.0 artifact and 0.1.1 development are separate lanes:
 - Merging `develop` into `main`, publishing a 0.1.1 tag or release, and any
   0.1.1 CRAN submission remain release actions governed by the T6 gates.
 
-Parallel development may begin before CRAN publication. The 0.1.0 closeout
-still requires the following steps after publication:
+Public publication, archive reconciliation, and installed-package UAT are now
+complete. Detailed evidence and release commands are maintained in
+[V0_1_0_ACCEPTANCE_CLOSEOUT.md](V0_1_0_ACCEPTANCE_CLOSEOUT.md).
 
-1. Download the published CRAN source tarball and calculate its SHA-256.
-2. Compare it with the submitted documentation/write-safety remediation
-   artifact SHA-256:
-   `21e6ecddeed86dad177708d7b7f3bf1df79059f769dedc0e0439e995e2fa5e74`.
-3. Install from CRAN in an isolated library and run the beginner smoke workflow.
-4. Update issue #4 with the CRAN URL, publication date, published checksum,
-   reviewer-remediation history, accepted source commit
-   `6214c0316d39154140bdba064266119007bff41a`, and the merged evidence-only
-   closeout commit.
-5. In a fresh clone, verify the accepted source commit from `main` before
+The remaining 0.1.0 closeout sequence is:
+
+1. On or after 2026-08-01 10:20 PDT, refresh the CRAN check page and inspect
+   every reported platform. The early six-result snapshot is all `OK` but is
+   not the final 48-hour matrix.
+2. Update issue #4 with the CRAN URL, publication date, submitted and published
+   checksums, explained CRAN metadata-only archive differences, reviewer
+   history, accepted source commit, installed UAT result, and final check
+   matrix.
+3. In a fresh clone, verify the accepted source commit from `main` before
    tagging:
 
    ```sh
@@ -66,7 +68,7 @@ still requires the following steps after publication:
    This commit is the exact source used to build the submitted remediation
    tarball. Later evidence-only commits change only files excluded from the
    package tarball; the release tag remains anchored to the accepted source.
-6. Obtain explicit approval before creating the annotated `v0.1.0` tag at the
+4. Obtain explicit approval before creating the annotated `v0.1.0` tag at the
    accepted package-content commit, publishing the GitHub release, or closing
    issue #4.
 


### PR DESCRIPTION
## Outcome

Memorializes the CRAN reviewer publication message and reconciles the public `engager` 0.1.0 artifact without changing package content.

The public package page, published source archive, accepted source commit, and installed workflow are verified. This PR remains draft until the 48-hour CRAN check-matrix refresh on or after 2026-08-01 10:20 PDT.

Tracks #4 without closing it.

## Scope

- preserves the incoming CRAN email under `project-docs/communications/inbox/`;
- records structured intake, owners, target dates, decisions, and open gates;
- replaces stale pre-remediation closeout hashes with the accepted source identity;
- updates the roadmap, validation report, and 0.1.1 release plan;
- changes only files beneath package-excluded `project-docs/`.

## Verified publication evidence

- CRAN package page: live, version 0.1.0, published 2026-07-30;
- submitted SHA-256: `21e6ecddeed86dad177708d7b7f3bf1df79059f769dedc0e0439e995e2fa5e74`;
- published SHA-256: `0051326ad8e0d648969a56b7d374ba9bb4560ffe0f380e201ec6d07ac860468b`;
- archive difference: only CRAN-normalized `DESCRIPTION` metadata and generated `MD5` manifest;
- accepted tag target: `6214c0316d39154140bdba064266119007bff41a`;
- published-tarball installed UAT: PASS on R 4.5.3 / aarch64-apple-darwin20;
- early CRAN matrix: six results, all `OK`.

## Validation

- `git diff --check`: pass;
- relative Markdown links: pass;
- stale pre-remediation commit/checksum scan: pass;
- published archive recursive comparison: no package-content differences beyond CRAN metadata and `MD5`;
- installed published-package UAT: PASS using bundled synthetic fixtures;
- `Rscript scripts/pre-pr-validation.R`: pass without repository mutation; zero test failures and no package-check errors or warnings.

## Boundaries

This draft does not authorize an annotated tag, GitHub release, issue #4 closure, `develop` promotion, or 0.1.2 implementation. Those remain separate actions. The CRAN documentation/write-safety remediation must be forward-ported to `develop` before the 0.1.1 candidate is rebuilt.