### PR TITLE
ci: separate remote CRAN incoming checks

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,6 +52,12 @@ jobs:
             any::rmarkdown
 
       - name: Check
+        # Remote incoming-feasibility checks are release-state dependent. Once
+        # a version is published, CRAN warns that the same version already
+        # exists even when package validation succeeds. Release candidates run
+        # the remote probe separately through win-builder and CRAN submission.
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: "false"
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ It runs `git diff --check`, the test suite, and `R CMD check --as-cran` in a
 temporary directory, then verifies that tracked and untracked state did not
 change. It does not generate or rewrite source files.
 
+Routine repository checks set `_R_CHECK_CRAN_INCOMING_REMOTE_=false`. The
+remote incoming-feasibility probe depends on CRAN publication state and warns
+when the repository still contains an already-published version, even when the
+package passes installation, examples, tests, vignettes, and local CRAN checks.
+Disabling that remote probe does not relax local `--as-cran` validation.
+Release candidates must still run the remote incoming checks through
+R-devel win-builder and the maintainer-controlled CRAN submission workflow.
+
 For R or roxygen changes, run `devtools::document()` intentionally, inspect the
 result, and commit `NAMESPACE` and `man/` updates. Required CI checks the
 committed package exactly; it does not rewrite package files before validation.

--- a/scripts/pre-pr-validation.R
+++ b/scripts/pre-pr-validation.R
@@ -25,8 +25,14 @@ run_git <- function(args, label) {
   output
 }
 
-run_external <- function(command, args, label) {
-  output <- system2(command, args, stdout = TRUE, stderr = TRUE)
+run_external <- function(command, args, label, env = character()) {
+  output <- system2(
+    command,
+    args,
+    stdout = TRUE,
+    stderr = TRUE,
+    env = env
+  )
   if (length(output) > 0L) {
     cat(paste(output, collapse = "\n"), "\n")
   }
@@ -111,7 +117,8 @@ main <- function() {
         paste0("--output=", check_output),
         tarballs[[1]]
       ),
-      "R CMD check --as-cran"
+      "R CMD check --as-cran",
+      env = "_R_CHECK_CRAN_INCOMING_REMOTE_=false"
     )
 
     package_name <- read.dcf(


### PR DESCRIPTION
## Outcome

Restores meaningful strict CI after `engager` 0.1.0 publication by disabling only the release-state-dependent remote CRAN incoming-feasibility probe during routine repository checks.

The prior workflow completed installation, examples, tests, vignettes, and documentation successfully on Linux, Windows, and macOS, then failed solely because CRAN correctly reported: `Insufficient package version (submitted: 0.1.0, existing: 0.1.0)`.

## Change class

- [ ] Routine
- [x] Governed — maintainer authorized this bounded CI-policy fix in the active orchestration task
- [ ] Release/external mutation

## Impact

- Package or user behavior: none; all changed paths are excluded by `.Rbuildignore`.
- Public API or schema: none.
- Privacy or data handling: none.
- Release discipline: remote incoming checks remain required through R-devel win-builder and maintainer-controlled CRAN submission.

## Changes

- set `_R_CHECK_CRAN_INCOMING_REMOTE_=false` for the hosted routine `--as-cran` check;
- apply the identical setting in the canonical local validator;
- document the routine-versus-release validation boundary in `CONTRIBUTING.md`.

All other `--as-cran` checks remain strict, including `error_on = "warning"` in hosted CI.

## Validation

- `git diff --check`: pass;
- R syntax parse: pass;
- workflow YAML parse: pass, including the quoted environment value;
- `Rscript scripts/pre-pr-validation.R`: exit 0 with zero test failures and no package-check errors or warnings;
- repository state unchanged by validation;
- negative evidence: PR #584 failed on all three platforms only at the now-inapplicable remote same-version probe.

## Risk and rollback

Risk: a routine PR no longer queries CRAN incoming feasibility. This is intentional because that probe is version/publication dependent rather than a local package-quality check. Release candidates retain remote validation through win-builder and CRAN. Revert this commit to restore the old behavior.

Relates to #4 and unblocks draft PR #584. Does not close either.