### PR TITLE
ci: forward-port remote CRAN incoming policy

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,6 +52,12 @@ jobs:
             any::rmarkdown
 
       - name: Check
+        # Remote incoming-feasibility checks are release-state dependent. Once
+        # a version is published, CRAN warns that the same version already
+        # exists even when package validation succeeds. Release candidates run
+        # the remote probe separately through win-builder and CRAN submission.
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: "false"
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ It runs `git diff --check`, the test suite, and `R CMD check --as-cran` in a
 temporary directory, then verifies that tracked and untracked state did not
 change. It does not generate or rewrite source files.
 
+Routine repository checks set `_R_CHECK_CRAN_INCOMING_REMOTE_=false`. The
+remote incoming-feasibility probe depends on CRAN publication state and warns
+when the repository still contains an already-published version, even when the
+package passes installation, examples, tests, vignettes, and local CRAN checks.
+Disabling that remote probe does not relax local `--as-cran` validation.
+Release candidates must still run the remote incoming checks through
+R-devel win-builder and the maintainer-controlled CRAN submission workflow.
+
 For R or roxygen changes, run `devtools::document()` intentionally, inspect the
 result, and commit `NAMESPACE` and `man/` updates. Required CI checks the
 committed package exactly; it does not rewrite package files before validation.

--- a/scripts/pre-pr-validation.R
+++ b/scripts/pre-pr-validation.R
@@ -25,8 +25,14 @@ run_git <- function(args, label) {
   output
 }
 
-run_external <- function(command, args, label) {
-  output <- system2(command, args, stdout = TRUE, stderr = TRUE)
+run_external <- function(command, args, label, env = character()) {
+  output <- system2(
+    command,
+    args,
+    stdout = TRUE,
+    stderr = TRUE,
+    env = env
+  )
   if (length(output) > 0L) {
     cat(paste(output, collapse = "\n"), "\n")
   }
@@ -111,7 +117,8 @@ main <- function() {
         paste0("--output=", check_output),
         tarballs[[1]]
       ),
-      "R CMD check --as-cran"
+      "R CMD check --as-cran",
+      env = "_R_CHECK_CRAN_INCOMING_REMOTE_=false"
     )
 
     package_name <- read.dcf(


### PR DESCRIPTION
## Summary

Forward-port the already-validated CI policy from main PR #589 to the 0.1.1 develop line. Routine local and hosted package checks disable only CRAN remote incoming-feasibility probing; release candidates still require remote validation through win-builder and the maintainer-controlled CRAN workflow.

## Scope and impact

- changes only the R-CMD-check workflow, canonical validator, and contribution policy
- changes no package source, public API, schema, privacy behavior, release evidence, or candidate checksum
- preserves 0.1.1 at the existing 37-export surface
- rollback is a single squash-commit revert

This governed repository-policy forward-port is authorized in the implementation task. Merge remains separately authorized after required checks and review-thread resolution. Related to issue #576.

## Validation

- exact patch comparison with main commit 185f2a8: pass
- git diff --check: pass
- R parser and YAML parser: pass
- canonical pre-PR validator: pass
- full tests: zero failures
- local R CMD check --as-cran: zero errors, zero warnings, one environment-only clock-verification note