### PR TITLE
Forward-port CRAN documentation and write safety to 0.1.1

### DIFF
--- a/R/analyze_transcripts.R
+++ b/R/analyze_transcripts.R
@@ -6,8 +6,10 @@
 #' @param transcripts_folder Path to folder containing transcript files
 #' @param names_to_exclude Vector of names to exclude from analysis (default: "dead_air")
 #' @param write Whether to write results to file (default: FALSE)
-#' @param output_path Path for output file (defaults to "engagement_metrics.csv")
-#' @return Data frame with engagement metrics
+#' @param output_path Explicit path for the output file when `write = TRUE`.
+#' @return A tibble with speaker-level engagement metrics for the discovered
+#'   transcript files. When `write = TRUE`, the same metrics are also written
+#'   to `output_path` after export privacy policies are applied.
 #'
 #' @export
 analyze_transcripts <- function(
@@ -17,6 +19,11 @@ analyze_transcripts <- function(
     output_path = NULL) {
   if (!dir.exists(transcripts_folder)) {
     stop(sprintf("Folder not found: %s", transcripts_folder))
+  }
+  if (isTRUE(write) && (is.null(output_path) || !is.character(output_path) ||
+    length(output_path) != 1L || is.na(output_path) ||
+    !nzchar(trimws(output_path)))) {
+    stop("`output_path` must be supplied when `write = TRUE`", call. = FALSE)
   }
 
   files <- list.files(transcripts_folder, pattern = "\\.transcript\\.vtt$", full.names = TRUE)
@@ -40,7 +47,7 @@ analyze_transcripts <- function(
     write_metrics(
       metrics,
       what = "engagement",
-      path = if (is.null(output_path)) "engagement_metrics.csv" else output_path
+      path = output_path
     )
   }
 

--- a/R/consolidate_transcript.R
+++ b/R/consolidate_transcript.R
@@ -13,11 +13,9 @@
 #'
 #' @param df A tibble containing transcript comments with columns: name, start, end, comment
 #' @param max_pause_sec Maximum pause in seconds between comments to consolidate (default: 1)
-#' @return A tibble with consolidated comments
-#'
-#'   transcript.
-#'
-#' consolidate_transcript(df = "NULL")
+#' @return A tibble with consecutive comments consolidated by speaker and pause
+#'   threshold, including `name`, `comment`, `start`, `end`, `duration`, and
+#'   `wordcount` columns. Returns `NULL` when `df` is not a tibble.
 #'
 #' @export
 consolidate_transcript <- function(df = NULL, max_pause_sec = 1) {

--- a/R/create_session_mapping.R
+++ b/R/create_session_mapping.R
@@ -2,7 +2,7 @@
 create_session_mapping <- function(
     zoom_recordings_df = NULL,
     course_info_df = NULL,
-    output_file = "session_mapping.csv",
+    output_file = NULL,
     semester_start_mdy = "Jan 01, 2024",
     auto_assign_patterns = list(
       "CS 101" = "CS.*101",
@@ -11,6 +11,15 @@ create_session_mapping <- function(
     ),
     interactive = FALSE,
     verbose = FALSE) {
+  if (!is.null(output_file) &&
+      (!is.character(output_file) || length(output_file) != 1L ||
+        is.na(output_file) || !nzchar(trimws(output_file)))) {
+    stop(
+      "`output_file` must be NULL or one explicit non-empty character path",
+      call. = FALSE
+    )
+  }
+
   # Validate inputs
   if (is.null(zoom_recordings_df) || is.null(course_info_df)) {
     return(tibble::tibble(

--- a/R/detect_duplicate_transcripts.R
+++ b/R/detect_duplicate_transcripts.R
@@ -119,33 +119,6 @@ calc_content_similarity_matrix <- function(existing_files, existing_names,
 #' @param method Detection method: "hybrid" (default), "content", or "metadata"
 #' @param names_to_exclude Vector of names to exclude from comparison (default: c("dead_air"))
 #' @return List containing duplicate groups, similarity matrix, and recommendations
-#' @examples
-#' \dontrun{
-#' # Create sample transcript list
-#' transcript_list <- tibble::tibble(
-#'   transcript_file = c(
-#'     "GMT20240115-100000_Recording.transcript.vtt",
-#'     "GMT20240115-100000_Recording.cc.vtt",
-#'     "GMT20240116-140000_Recording.transcript.vtt"
-#'   )
-#' )
-#'
-#' # Detect duplicates in a transcript list
-#' duplicates <- detect_duplicate_transcripts(transcript_list)
-#'
-#' # View duplicate groups
-#' duplicates$duplicate_groups
-#'
-#' # View recommendations
-#' duplicates$recommendations
-#'
-#' # Use different detection method
-#' content_duplicates <- detect_duplicate_transcripts(
-#'   transcript_list,
-#'   method = "content",
-#'   similarity_threshold = 0.9
-#' )
-#' }
 #'
 #' @seealso
 #' \code{\link{process_zoom_transcript}} for processing individual transcripts,

--- a/R/ensure_privacy.R
+++ b/R/ensure_privacy.R
@@ -20,9 +20,11 @@
 #'   "ferpa_standard" are accepted with a warning.
 #' @param id_columns Vector of column names to treat as identifiers (default: common name columns)
 #' @param audit_log Whether to log privacy operations (default: TRUE)
-#' @return A privacy-processed version of the input object. This is a technical
-#'   masking result, not a legal or institutional compliance determination.
-#'
+#' @return For tabular input, an object with the same data-frame class as `x`
+#'   and configured identifier columns transformed according to `privacy_level`.
+#'   Non-tabular input is returned unchanged. This is a technical masking result,
+#'   not a legal or institutional compliance determination.
+#' @examples
 #' df <- tibble::tibble(
 #'   section = c("A", "A", "B"),
 #'   preferred_name = c("Alice Johnson", "Bob Lee", "Cara Diaz"),

--- a/R/ethical_compliance.R
+++ b/R/ethical_compliance.R
@@ -293,16 +293,6 @@ create_ethical_use_report <- function(usage_context = NULL,
 #' @param time_period Time period for analysis in days (default: 30)
 #' @return Audit report with ethical usage analysis
 #' @keywords internal
-#' @examples
-#' \dontrun{
-#' # Audit usage patterns
-#' audit <- audit_ethical_usage(
-#'   function_calls = c("analyze_transcripts", "plot_users", "write_metrics"),
-#'   data_sizes = c(100, 150, 200),
-#'   privacy_settings = c("mask", "mask", "privacy_strict"),
-#'   time_period = 30
-#' )
-#' }
 audit_ethical_usage <- function(function_calls = NULL,
                                 data_sizes = NULL,
                                 privacy_settings = NULL,

--- a/R/load_cancelled_classes.R
+++ b/R/load_cancelled_classes.R
@@ -1,14 +1,42 @@
 #' @importFrom magrittr %>%
 # Internal function - no documentation needed
-load_cancelled_classes <- function(data_folder = ".",
+load_cancelled_classes <- function(data_folder = NULL,
                                    cancelled_classes_file = "cancelled_classes.csv",
                                    cancelled_classes_col_types = "ccccccccnnnncTTcTTccci",
                                    write_blank_cancelled_classes = FALSE) {
-  cancelled_classes_file_path <-
-    paste0(data_folder, "/", cancelled_classes_file)
+  if (!is.null(data_folder) &&
+      (!is.character(data_folder) || length(data_folder) != 1L ||
+        is.na(data_folder) || !nzchar(trimws(data_folder)))) {
+    stop(
+      "`data_folder` must be NULL or an explicit non-empty directory path.",
+      call. = FALSE
+    )
+  }
+  if (!is.character(cancelled_classes_file) ||
+      length(cancelled_classes_file) != 1L ||
+      is.na(cancelled_classes_file) ||
+      !nzchar(trimws(cancelled_classes_file))) {
+    stop(
+      "`cancelled_classes_file` must be one explicit non-empty file name.",
+      call. = FALSE
+    )
+  }
+  if (isTRUE(write_blank_cancelled_classes) &&
+      is.null(data_folder)) {
+    stop(
+      "`data_folder` must be supplied when `write_blank_cancelled_classes = TRUE`.",
+      call. = FALSE
+    )
+  }
+
+  cancelled_classes_file_path <- if (is.null(data_folder)) {
+    NULL
+  } else {
+    file.path(data_folder, cancelled_classes_file)
+  }
 
   # Check if the file exists
-  if (file.exists(cancelled_classes_file_path)) {
+  if (!is.null(cancelled_classes_file_path) && file.exists(cancelled_classes_file_path)) {
     # File exists, proceed with importing it
     data <- readr::read_csv(cancelled_classes_file_path,
       col_types = cancelled_classes_col_types,
@@ -16,12 +44,14 @@ load_cancelled_classes <- function(data_folder = ".",
     )
   } else {
     # File doesn't exist, handle the situation accordingly
-    warning(paste("File does not exist:", cancelled_classes_file_path))
+    if (!is.null(cancelled_classes_file_path)) {
+      warning(paste("File does not exist:", cancelled_classes_file_path))
+    }
     data <- make_blank_cancelled_classes_df()
 
     if (write_blank_cancelled_classes && !file.exists(cancelled_classes_file_path)) {
       data %>%
-        readr::write_csv(paste0(data_folder, "/", cancelled_classes_file))
+        readr::write_csv(cancelled_classes_file_path)
     } else if (!write_blank_cancelled_classes) {
       # keep returning blank template to preserve legacy behavior
     }

--- a/R/load_roster.R
+++ b/R/load_roster.R
@@ -3,8 +3,18 @@
 #' @param data_folder Directory containing the roster file
 #' @param roster_file Name of the roster CSV file
 #' @param strict_errors Logical; if TRUE, throw error when file doesn't exist
-#' @return A tibble with roster data, filtered by enrolled status if applicable
+#' @return A tibble containing the roster rows. When an `enrolled` column is
+#'   present, only rows where it is `TRUE` are returned. A missing file returns
+#'   an empty tibble unless `strict_errors = TRUE`.
 #' @export
+#' @examples
+#' roster_path <- tempfile(fileext = ".csv")
+#' readr::write_csv(
+#'   tibble::tibble(student_id = "S001", preferred_name = "Student One"),
+#'   roster_path
+#' )
+#' roster <- load_roster(roster_path)
+#' unlink(roster_path)
 load_roster <- function(
     data_folder = ".",
     roster_file = "roster.csv",

--- a/R/load_session_mapping.R
+++ b/R/load_session_mapping.R
@@ -2,21 +2,6 @@
 # This function loads a session mapping file created by `create_session_mapping()`
 # and integrates it with the Zoom recordings data to provide reliable course
 # information for analysis.
-#
-#
-#
-# \dontrun{
-# # Load session mapping
-# session_mapping <- load_session_mapping("session_mapping.csv")
-#
-# # Load and merge with Zoom recordings
-# zoom_recordings_df <- load_zoom_recorded_sessions_list()
-# mapped_recordings <- load_session_mapping(
-#   "session_mapping.csv",
-#   zoom_recordings_df = zoom_recordings_df
-# )
-# }
-
 # Internal function - no documentation needed
 load_mapping_file <- function(mapping_file) {
   # Check if mapping file exists

--- a/R/load_zoom_transcript.R
+++ b/R/load_zoom_transcript.R
@@ -8,7 +8,9 @@
 #' https://gist.github.com/brooksambrose/1a8a673eb3bf884c1868ad4d80f08246
 #'
 #' @param transcript_file_path Path to the transcript file to load
-#' @return A tibble containing the transcript data, or NULL if the file is empty
+#' @return A tibble with one row per parsed WebVTT cue and columns describing
+#'   speaker name, cue text, start and end times, duration, word count, and
+#'   source transcript. Returns `NULL` when the file is empty.
 #' @examples
 #' # Load a sample transcript from the package's extdata directory
 #' transcript_file <- system.file("extdata/test_transcripts/intro_statistics_week1.vtt",

--- a/R/lookup_merge_utils.R
+++ b/R/lookup_merge_utils.R
@@ -71,8 +71,9 @@ NULL
 
 # Internal function - no documentation needed
 read_lookup_safely <- function(path = NULL) {
-  if (!is.character(path) || length(path) != 1) {
-    stop("path must be a single character string", call. = FALSE)
+  if (!is.character(path) || length(path) != 1L ||
+      is.na(path) || !nzchar(trimws(path))) {
+    stop("path must be one explicit non-empty character path", call. = FALSE)
   }
   if (!file.exists(path)) {
     return(.normalize_lookup_df(data.frame(stringsAsFactors = FALSE)))
@@ -99,8 +100,9 @@ merge_lookup_preserve <- function(existing_df = NULL, add_df = NULL) {
 
 # Internal function - no documentation needed
 write_lookup_transactional <- function(df = NULL, path = NULL) {
-  if (!is.character(path) || length(path) != 1) {
-    stop("path must be a single character string", call. = FALSE)
+  if (!is.character(path) || length(path) != 1L ||
+      is.na(path) || !nzchar(trimws(path))) {
+    stop("path must be one explicit non-empty character path", call. = FALSE)
   }
   df <- .normalize_lookup_df(df)
   dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)

--- a/R/plot_users.R
+++ b/R/plot_users.R
@@ -9,7 +9,8 @@
 #' @param mask_by Masking option: "name" or "rank" (default: "name")
 #' @param privacy_level Privacy level for data visualization (default: from global option)
 #' @param metrics_lookup_df Optional lookup table for metric names (default: NULL)
-#' @return A ggplot2 object
+#' @return A `ggplot` object whose data contains the selected metric and the
+#'   configured privacy-processed participant labels, ready to print or modify.
 #'
 #' @export
 plot_users <- function(

--- a/R/privacy_audit.R
+++ b/R/privacy_audit.R
@@ -4,7 +4,9 @@
 #'
 #' @param data A tibble containing the data to audit
 #' @param id_columns Vector of column names to check for identifiers (default: common name columns)
-#' @return A tibble containing audit results with columns: column, values, non_empty, masked_estimate
+#' @return A tibble with one row per detected identifier column and the fields
+#'   `column`, `values`, `non_empty`, and `masked_estimate`, summarizing the
+#'   technical masking state of the supplied data.
 #'
 #' @export
 privacy_audit <- function(

--- a/R/privacy_review.R
+++ b/R/privacy_review.R
@@ -25,8 +25,9 @@ NULL
 #' @param custom_retention_days Custom retention period in days, used when
 #'   `retention_period = "custom"`.
 #' @param audit_log Whether to record an in-memory review audit event.
-#' @return A list with technical review status, detected fields, recommendations,
-#'   retention check details, and institutional review prompts.
+#' @return A named list containing the logical technical review status,
+#'   detected identifier fields, recommendations, retention-review details,
+#'   and institutional review prompts.
 #' @export
 review_privacy_risks <- function(data = NULL,
                                  institution_type = c("educational", "research", "mixed"),
@@ -200,7 +201,8 @@ validate_ferpa_compliance <- function(data = NULL,
 #' @param hash_salt Required non-empty salt for hash-based transformation.
 #' @param aggregation_level Reserved for a future aggregation workflow. It has
 #'   no effect for supported version 0.1.0 methods.
-#' @return Data frame with recognized structured identifier columns transformed.
+#' @return A data frame of the same row shape as `data`, with recognized
+#'   structured identifier columns transformed by the selected method.
 #'   Missing and blank identifiers remain missing or blank. These transformations
 #'   do not inspect free text and do not establish that a data set is anonymous or
 #'   compliant with legal or institutional requirements.
@@ -347,8 +349,9 @@ apply_hash_anonymization <- function(data, columns_to_anonymize, hash_salt) {
 #' @param include_audit_trail Whether to include basic report metadata.
 #' @param institution_info Optional institution-provided metadata to include.
 #' @param institution_type Review context: "educational", "research", or "mixed".
-#' @return A list containing report metadata, summary, review results, and
-#'   recommendations.
+#' @return A named list containing report metadata, a summary, the underlying
+#'   technical review results, and recommendations. When `output_file` is
+#'   supplied, the same report is also serialized there.
 #' @export
 generate_privacy_review_report <- function(data = NULL,
                                            output_file = NULL,
@@ -356,6 +359,7 @@ generate_privacy_review_report <- function(data = NULL,
                                            include_audit_trail = TRUE,
                                            institution_info = NULL,
                                            institution_type = c("educational", "research", "mixed")) {
+  validate_optional_privacy_report_path(output_file)
   report_format <- match.arg(report_format)
   institution_type <- match.arg(institution_type)
 
@@ -409,6 +413,7 @@ write_privacy_review_report <- function(report,
                                         report_format,
                                         status_field,
                                         status_label) {
+  validate_optional_privacy_report_path(output_file, allow_null = FALSE)
   if (report_format == "json") {
     jsonlite::write_json(report, output_file, pretty = TRUE)
   } else if (report_format == "html") {
@@ -435,6 +440,21 @@ write_privacy_review_report <- function(report,
   }
 }
 
+validate_optional_privacy_report_path <- function(output_file, allow_null = TRUE) {
+  if (is.null(output_file) && isTRUE(allow_null)) {
+    return(invisible(TRUE))
+  }
+  if (is.null(output_file) || !is.character(output_file) ||
+      length(output_file) != 1L || is.na(output_file) ||
+      !nzchar(trimws(output_file))) {
+    stop(
+      "`output_file` must be NULL or one explicit non-empty character path.",
+      call. = FALSE
+    )
+  }
+  invisible(TRUE)
+}
+
 # Deprecated compatibility wrapper. Kept unexported because the old helper was
 # not part of the public NAMESPACE, but tests and historical scripts may call it.
 generate_ferpa_report <- function(data = NULL,
@@ -442,6 +462,7 @@ generate_ferpa_report <- function(data = NULL,
                                   report_format = c("text", "html", "json"),
                                   include_audit_trail = TRUE,
                                   institution_info = NULL) {
+  validate_optional_privacy_report_path(output_file)
   .Deprecated("generate_privacy_review_report")
   report <- generate_privacy_review_report(
     data = data,
@@ -480,22 +501,6 @@ generate_ferpa_report <- function(data = NULL,
 #'   field is the preferred status name; `compliant` is retained as a
 #'   backward-compatible alias.
 #' @keywords internal
-#' @examples
-#' \dontrun{
-#' # Check data retention policy
-#' sample_data <- tibble::tibble(
-#'   student_id = c("12345", "67890"),
-#'   session_date = as.Date(c("2024-01-15", "2024-02-20")),
-#'   participation_score = c(85, 92)
-#' )
-#'
-#' retention_check <- check_data_retention_policy(
-#'   sample_data,
-#'   retention_period = "academic_year",
-#'   date_column = "session_date"
-#' )
-#' print(retention_check$passed)
-#' }
 check_data_retention_policy <- function(data = NULL,
                                         retention_period = c("academic_year", "semester", "quarter", "custom"),
                                         custom_retention_days = NULL,

--- a/R/process_zoom_transcript.R
+++ b/R/process_zoom_transcript.R
@@ -15,7 +15,9 @@
 #' @param dead_air_name Name to use for dead air periods (default: 'dead_air')
 #' @param na_name Name to use for unknown speakers (default: 'unknown')
 #' @param transcript_df Pre-loaded transcript data frame (alternative to transcript_file_path)
-#' @return A tibble containing the processed transcript data
+#' @return A tibble of processed transcript cues with normalized speaker,
+#'   comment, timing, duration, word-count, and source-file fields. Depending on
+#'   the arguments, adjacent cues may be consolidated and dead-air rows added.
 #' @examples
 #' # Load a sample transcript from the package's extdata directory
 #' transcript_file <- system.file("extdata/test_transcripts/intro_statistics_week1.vtt",

--- a/R/prompt_name_matching.R
+++ b/R/prompt_name_matching.R
@@ -4,9 +4,10 @@ prompt_name_matching <- function(unmatched_names = NULL,
                                    "engager.privacy_level",
                                    "mask"
                                  ),
-                                 data_folder = ".",
+                                 data_folder = NULL,
                                  section_names_lookup_file = "section_names_lookup.csv",
-                                 include_instructions = TRUE) {
+                                 include_instructions = TRUE,
+                                 write_lookup = FALSE) {
   # Validate inputs
   if (!is.character(unmatched_names)) {
     stop("unmatched_names must be a character vector", call. = FALSE)
@@ -14,16 +15,24 @@ prompt_name_matching <- function(unmatched_names = NULL,
 
   privacy_level <- normalize_privacy_level(privacy_level)
 
-  if (!is.character(data_folder) || length(data_folder) != 1) {
-    stop("data_folder must be a single character string", call. = FALSE)
+  if (!is.null(data_folder) &&
+      (!is.character(data_folder) || length(data_folder) != 1L ||
+        is.na(data_folder) || !nzchar(trimws(data_folder)))) {
+    stop("data_folder must be NULL or a non-empty character string", call. = FALSE)
   }
 
-  if (!is.character(section_names_lookup_file) || length(section_names_lookup_file) != 1) {
+  if (!is.character(section_names_lookup_file) ||
+      length(section_names_lookup_file) != 1L ||
+      is.na(section_names_lookup_file) ||
+      !nzchar(trimws(section_names_lookup_file))) {
     stop("section_names_lookup_file must be a single character string", call. = FALSE)
   }
 
   if (!is.logical(include_instructions) || length(include_instructions) != 1) {
     stop("include_instructions must be a single logical value", call. = FALSE)
+  }
+  if (!is.logical(write_lookup) || length(write_lookup) != 1 || is.na(write_lookup)) {
+    stop("write_lookup must be a single logical value", call. = FALSE)
   }
 
   # If no unmatched names, return early
@@ -32,12 +41,6 @@ prompt_name_matching <- function(unmatched_names = NULL,
       message("No unmatched names found. Name matching is complete.")
     }
     return(invisible(NULL))
-  }
-
-  # Create data folder if it doesn't exist
-  if (!dir.exists(data_folder)) {
-    dir.create(data_folder, recursive = TRUE)
-    # Created data folder
   }
 
   # Generate privacy-safe guidance
@@ -52,17 +55,23 @@ prompt_name_matching <- function(unmatched_names = NULL,
     cat("\n", guidance, "\n", sep = "")
   }
 
-  # Create the lookup file using existing function
-  lookup_file_path <- file.path(data_folder, section_names_lookup_file)
-
   # Use existing function to create blank template
   lookup_template <- make_blank_section_names_lookup_csv()
 
+  if (!isTRUE(write_lookup)) {
+    return(invisible(lookup_template))
+  }
+
+  if (is.null(data_folder)) {
+    stop("`data_folder` must be supplied when `write_lookup = TRUE`", call. = FALSE)
+  }
+  lookup_file_path <- file.path(data_folder, section_names_lookup_file)
+  if (!dir.exists(data_folder)) {
+    dir.create(data_folder, recursive = TRUE)
+  }
+
   # Save the template to the specified file
   readr::write_csv(lookup_template, lookup_file_path)
-
-  # Created lookup file
-  # Please edit this file to map the unmatched names, then re-run your analysis.
 
   # Return the file path invisibly
   invisible(lookup_file_path)
@@ -101,8 +110,8 @@ generate_name_matching_guidance <- function(unmatched_names, privacy_level, incl
   if (include_instructions) {
     instructions_msg <- paste(
       "\n\n*** INSTRUCTIONS:",
-      "1. Open the created 'section_names_lookup.csv' file",
-      "2. Add rows for each unmatched name above",
+      "1. Review the in-memory lookup template returned by prompt_name_matching()",
+      "2. Choose an explicit output directory and call prompt_name_matching(..., data_folder = output_dir, write_lookup = TRUE) if a CSV template is needed",
       "3. Map each transcript name to the correct roster name",
       "4. Set 'participant_type' to one of:",
       "   - 'instructor' for faculty/staff",

--- a/R/safe_name_matching_workflow.R
+++ b/R/safe_name_matching_workflow.R
@@ -12,21 +12,10 @@
 #'   Defaults to `getOption("engager.unmatched_names_action", "stop")`.
 #' @param data_folder Directory containing data files
 #' @param section_names_lookup_file Name of the section names lookup file
+#' @param write_lookup Logical; whether the unmatched-name flow may write a
+#'   lookup template to the explicitly selected `data_folder`.
 #'
 #' @return Processed transcript data with privacy-aware name matching applied
-#' @examples
-#' # Default behavior (maximum privacy)
-#' # result <- safe_name_matching_workflow(
-#' #   transcript_file_path = "transcript.vtt",
-#' #   roster_data = roster_df
-#' # )
-#' #
-#' # Opt-in for convenience
-#' # result <- safe_name_matching_workflow(
-#' #   transcript_file_path = "transcript.vtt",
-#' #   roster_data = roster_df,
-#' #   unmatched_names_action = "warn"
-#' # )
 safe_name_matching_workflow <- function(transcript_file_path = NULL,
                                         roster_data = NULL,
                                         privacy_level = getOption(
@@ -37,12 +26,13 @@ safe_name_matching_workflow <- function(transcript_file_path = NULL,
                                           "engager.unmatched_names_action",
                                           "stop"
                                         ),
-                                        data_folder = ".",
-                                        section_names_lookup_file = "section_names_lookup.csv") {
+                                        data_folder = NULL,
+                                        section_names_lookup_file = "section_names_lookup.csv",
+                                        write_lookup = FALSE) {
   # Validate inputs
   validate_safe_name_inputs(
     transcript_file_path, roster_data, privacy_level,
-    unmatched_names_action, data_folder, section_names_lookup_file
+    unmatched_names_action, data_folder, section_names_lookup_file, write_lookup
   )
 
   # Stage 1: Load and process with real names in memory (quiet by default)
@@ -57,7 +47,7 @@ safe_name_matching_workflow <- function(transcript_file_path = NULL,
   # Process name matching workflow
   processed_data <- process_name_matching_workflow(
     transcript_data, roster_data, name_mappings, unmatched_names_action,
-    privacy_level, data_folder, section_names_lookup_file
+    privacy_level, data_folder, section_names_lookup_file, write_lookup
   )
 
   # Name matching workflow completed successfully
@@ -95,7 +85,8 @@ handle_unmatched_names <- function(unmatched_names,
                                    unmatched_names_action,
                                    privacy_level,
                                    data_folder,
-                                   section_names_lookup_file) {
+                                   section_names_lookup_file,
+                                   write_lookup = FALSE) {
   # Extract actual names from transcript data for unmatched entries only
   actual_names <- extract_unmatched_names_from_transcript(unmatched_names, transcript_data)
 
@@ -104,14 +95,14 @@ handle_unmatched_names <- function(unmatched_names,
     stop(
       paste0(
         "Found unmatched names: ", paste(actual_names, collapse = ", "), "\n",
-        "Please update your section_names_lookup.csv file with these mappings.\n",
-        "See ?match_names_workflow and ?write_unresolved for detailed instructions.\n",
+        "No mapping file was created.\n",
+        "Use ?match_names_workflow to review matches in memory, then call ",
+        "write_unresolved(..., path = 'your/output.csv') with an explicit path if needed.\n",
         "Example mappings:\n",
         paste(sapply(actual_names, function(name) {
           paste0("  ", name, " -> [Your roster name]")
         }), collapse = "\n"), "\n",
-        "Lookup file path: ", file.path(data_folder, section_names_lookup_file), "\n",
-        "For guided assistance, set unmatched_names_action = 'warn' to receive a template."
+        "For guided assistance, set unmatched_names_action = 'warn' to receive an in-memory template."
       ),
       call. = FALSE
     )
@@ -123,17 +114,33 @@ handle_unmatched_names <- function(unmatched_names,
     )
 
     # Prompt user for name matching
-    prompt_name_matching(
+    lookup_result <- prompt_name_matching(
       unmatched_names = actual_names,
       privacy_level = privacy_level,
       data_folder = data_folder,
-      section_names_lookup_file = section_names_lookup_file
+      section_names_lookup_file = section_names_lookup_file,
+      write_lookup = write_lookup
     )
 
-    # Stop processing to allow user to update mappings
-    stop(
-      "Please update the name mappings file and re-run the analysis.",
-      call. = FALSE
+    lookup_path <- if (isTRUE(write_lookup)) lookup_result else NULL
+    lookup_template <- if (isTRUE(write_lookup)) NULL else lookup_result
+    recovery <- if (isTRUE(write_lookup)) {
+      paste0("A lookup template was written to: ", lookup_path, ".")
+    } else {
+      paste(
+        "No file was written.",
+        "The error condition contains an in-memory `lookup_template` field.",
+        "Choose an explicit destination and call prompt_name_matching(...,",
+        "data_folder = output_dir, write_lookup = TRUE) to write it."
+      )
+    }
+
+    # Stop processing while preserving a supported recovery object.
+    rlang::abort(
+      paste("Name mappings are required before analysis can continue.", recovery),
+      class = "engager_name_matching_required",
+      lookup_template = lookup_template,
+      lookup_path = lookup_path
     )
   }
 }
@@ -407,9 +414,13 @@ apply_name_matching <- function(transcript_data, name_lookup, roster_data) {
 
 # Helper function to validate safe name matching inputs
 validate_safe_name_inputs <- function(transcript_file_path, roster_data, privacy_level,
-                                      unmatched_names_action, data_folder, section_names_lookup_file) {
+                                      unmatched_names_action, data_folder,
+                                      section_names_lookup_file, write_lookup = FALSE) {
   # Validate inputs
-  if (!is.character(transcript_file_path) || length(transcript_file_path) != 1) {
+  if (!is.character(transcript_file_path) ||
+      length(transcript_file_path) != 1L ||
+      is.na(transcript_file_path) ||
+      !nzchar(trimws(transcript_file_path))) {
     stop("transcript_file_path must be a single character string", call. = FALSE)
   }
 
@@ -431,12 +442,23 @@ validate_safe_name_inputs <- function(transcript_file_path, roster_data, privacy
     )
   }
 
-  if (!is.character(data_folder) || length(data_folder) != 1) {
-    stop("data_folder must be a single character string", call. = FALSE)
+  if (!is.null(data_folder) &&
+      (!is.character(data_folder) || length(data_folder) != 1L ||
+        is.na(data_folder) || !nzchar(trimws(data_folder)))) {
+    stop("data_folder must be NULL or a non-empty character string", call. = FALSE)
   }
 
-  if (!is.character(section_names_lookup_file) || length(section_names_lookup_file) != 1) {
+  if (!is.character(section_names_lookup_file) ||
+      length(section_names_lookup_file) != 1L ||
+      is.na(section_names_lookup_file) ||
+      !nzchar(trimws(section_names_lookup_file))) {
     stop("section_names_lookup_file must be a single character string", call. = FALSE)
+  }
+  if (!is.logical(write_lookup) || length(write_lookup) != 1 || is.na(write_lookup)) {
+    stop("write_lookup must be a single logical value", call. = FALSE)
+  }
+  if (isTRUE(write_lookup) && is.null(data_folder)) {
+    stop("`data_folder` must be supplied when `write_lookup = TRUE`", call. = FALSE)
   }
 
   # Validate roster has at least one usable name column and non-empty values
@@ -548,7 +570,8 @@ load_name_mappings <- function(data_folder, section_names_lookup_file) {
 # Helper function to process name matching workflow
 process_name_matching_workflow <- function(transcript_data, roster_data, name_mappings,
                                            unmatched_names_action, privacy_level,
-                                           data_folder, section_names_lookup_file) {
+                                           data_folder, section_names_lookup_file,
+                                           write_lookup = FALSE) {
   # Prepare roster data for matching (validate schema and compute hashes)
   roster_data <- validate_roster_for_matching(roster_data)
   roster_data <- compute_roster_hashes(roster_data)
@@ -569,7 +592,8 @@ process_name_matching_workflow <- function(transcript_data, roster_data, name_ma
       unmatched_names_action = unmatched_names_action,
       privacy_level = privacy_level,
       data_folder = data_folder,
-      section_names_lookup_file = section_names_lookup_file
+      section_names_lookup_file = section_names_lookup_file,
+      write_lookup = write_lookup
     )
   }
 

--- a/R/summarize_transcript_files.R
+++ b/R/summarize_transcript_files.R
@@ -9,16 +9,20 @@
 #' @param deduplicate_content Whether to detect and handle duplicate content (default: FALSE)
 #' @param similarity_threshold Similarity threshold for duplicate detection (default: 0.95)
 #' @param duplicate_method Method for duplicate detection: "hybrid", "content", or "metadata" (default: "hybrid")
-#' @return A tibble containing summarized transcript metrics
+#' @return A tibble of speaker-level metrics combined across the requested
+#'   transcript files. Metadata columns supplied with `transcript_file_names`
+#'   are retained in the result.
 #' @examples
-#' # Create sample transcript file names
+#' transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
 #' transcript_files <- c(
-#'   "GMT20240115-100000_Recording.transcript.vtt",
-#'   "GMT20240116-140000_Recording.transcript.vtt"
+#'   "ideal_course_session1.vtt",
+#'   "ideal_course_session2.vtt"
 #' )
-#'
-#' # Summarize transcript files
-#' summary <- summarize_transcript_files(transcript_file_names = transcript_files)
+#' summary <- summarize_transcript_files(
+#'   transcript_file_names = transcript_files,
+#'   data_folder = transcript_dir,
+#'   transcripts_folder = "."
+#' )
 #'
 #' @export
 summarize_transcript_files <-

--- a/R/summarize_transcript_metrics.R
+++ b/R/summarize_transcript_metrics.R
@@ -17,8 +17,9 @@
 #' @param transcript_df Pre-loaded transcript data frame (alternative to transcript_file_path)
 #' @param comments_format Format for comments: "list", "text", or "count" (default: "list")
 #' @return A tibble with one row per speaker (and source transcript when
-#'   present), containing participation totals such as duration, word count,
-#'   session count, and the configured comment representation.
+#'   present). The `n` column counts processed cue/comment segments; other
+#'   columns contain total speaking duration, word count, percentage measures,
+#'   words per minute, and the configured comment representation.
 #'
 #' @details This function preserves in-memory comment data for analysis
 #' compatibility. Use `write_metrics()` for privacy-safe CSV exports. The

--- a/R/summarize_transcript_metrics.R
+++ b/R/summarize_transcript_metrics.R
@@ -16,7 +16,9 @@
 #' @param na_name Name to use for unknown speakers (default: 'unknown')
 #' @param transcript_df Pre-loaded transcript data frame (alternative to transcript_file_path)
 #' @param comments_format Format for comments: "list", "text", or "count" (default: "list")
-#' @return A tibble containing summary metrics by speaker
+#' @return A tibble with one row per speaker (and source transcript when
+#'   present), containing participation totals such as duration, word count,
+#'   session count, and the configured comment representation.
 #'
 #' @details This function preserves in-memory comment data for analysis
 #' compatibility. Use `write_metrics()` for privacy-safe CSV exports. The

--- a/R/ux_basic_workflow.R
+++ b/R/ux_basic_workflow.R
@@ -6,24 +6,26 @@
 #' Complete basic transcript analysis workflow
 #'
 #' @description This is the main function for new users. It performs a complete
-#'   analysis workflow in 5 simple steps: load, process, analyze, visualize, and export.
+#'   analysis workflow in five simple steps: load, process, analyze, visualize,
+#'   and either return results in memory or export to an explicit directory.
 #'
 #' @param transcript_file Path to a WebVTT transcript file
-#' @param output_dir Output directory for results (default: "output")
+#' @param output_dir Optional output directory. When `NULL` (the default), the
+#'   analysis is returned in memory and no files or directories are created.
 #' @param privacy_level Privacy protection level: "high" (default), "medium",
 #'   or "low". These map to `"privacy_strict"`, `"privacy_standard"`, and
 #'   `"mask"`, respectively. All three levels mask common identifiers.
-#' @return List containing analysis results, plots, and output directory path
+#' @return A named list with `analysis` (a tibble of speaker metrics), `plots`
+#'   (a `ggplot` object), `output_dir` (the explicit output directory or
+#'   `NULL`), `transcript_file`, and `privacy_level`.
 #' @export
 #' @examples
-#' \dontrun{
-#' # Basic workflow for new users
-#' results <- basic_transcript_analysis("transcript.vtt", "output/")
-#'
-#' # With custom privacy level
-#' results <- basic_transcript_analysis("transcript.vtt", "output/", "medium")
-#' }
-basic_transcript_analysis <- function(transcript_file, output_dir = "output", privacy_level = "high") {
+#' transcript_file <- system.file(
+#'   "extdata/test_transcripts/ideal_course_session1.vtt",
+#'   package = "engager"
+#' )
+#' results <- basic_transcript_analysis(transcript_file)
+basic_transcript_analysis <- function(transcript_file, output_dir = NULL, privacy_level = "high") {
   # Validate inputs
   if (!file.exists(transcript_file)) {
     stop(
@@ -32,12 +34,14 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
     )
   }
 
-  if (!dir.exists(output_dir)) {
+  validate_optional_output_dir(output_dir)
+  normalized_privacy_level <- normalize_basic_privacy_level(privacy_level)
+
+  if (!is.null(output_dir) && !dir.exists(output_dir)) {
     message("Creating output directory: ", output_dir)
     dir.create(output_dir, recursive = TRUE)
   }
 
-  normalized_privacy_level <- normalize_basic_privacy_level(privacy_level)
   previous_privacy_level <- getOption("engager.privacy_level")
   on.exit(options(engager.privacy_level = previous_privacy_level), add = TRUE)
   options(engager.privacy_level = normalized_privacy_level)
@@ -46,7 +50,7 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
   message("==> Starting Basic Transcript Analysis")
   message(paste(rep("=", 40), collapse = ""))
   message("FILE: File: ", basename(transcript_file))
-  message("DIR: Output: ", output_dir)
+  message("DIR: Output: ", if (is.null(output_dir)) "in memory" else output_dir)
   message("PRIVACY: Privacy: ", privacy_level)
   message("")
 
@@ -90,23 +94,29 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
       )
       message("SUCCESS: Created engagement visualizations")
 
-      # Step 5: Export results
-      message("Step 5/5: Exporting results...")
-      output_path <- file.path(output_dir, "engagement_metrics.csv")
-      write_metrics(
-        analysis,
-        what = "engagement",
-        path = output_path,
-        privacy_level = normalized_privacy_level,
-        comments_policy = "omit"
-      )
-      message("SUCCESS: Exported results to ", output_dir)
+      # Step 5: Export results only when explicitly requested
+      if (!is.null(output_dir)) {
+        message("Step 5/5: Exporting results...")
+        output_path <- file.path(output_dir, "engagement_metrics.csv")
+        write_metrics(
+          analysis,
+          what = "engagement",
+          path = output_path,
+          privacy_level = normalized_privacy_level,
+          comments_policy = "omit"
+        )
+        message("SUCCESS: Exported results to ", output_dir)
+      } else {
+        message("Step 5/5: Returning results in memory (no output directory supplied)")
+      }
 
       message("")
       message("COMPLETE: Basic analysis complete!")
-      message("RESULTS: Results saved to: ", output_dir)
+      message("RESULTS: Results ", if (is.null(output_dir)) "returned in memory" else paste0("saved to: ", output_dir))
       message("TIP: Next steps:")
-      message("   - Check the output files in ", output_dir)
+      if (!is.null(output_dir)) {
+        message("   - Check the output files in ", output_dir)
+      }
       message("   - Use show_available_functions() to see more options")
       message("   - Use set_ux_level('intermediate') for more functions")
 
@@ -125,6 +135,24 @@ basic_transcript_analysis <- function(transcript_file, output_dir = "output", pr
       stop(e)
     }
   )
+}
+
+# Internal validation shared by the beginner workflows. Validate before any
+# directory creation so malformed destinations fail without side effects.
+validate_optional_output_dir <- function(output_dir) {
+  if (is.null(output_dir)) {
+    return(invisible(NULL))
+  }
+
+  if (!is.character(output_dir) || length(output_dir) != 1L ||
+      is.na(output_dir) || !nzchar(trimws(output_dir))) {
+    stop(
+      "`output_dir` must be NULL or an explicit non-empty directory path",
+      call. = FALSE
+    )
+  }
+
+  invisible(output_dir)
 }
 
 # Internal mapping retained for the beginner-facing high/medium/low API.
@@ -150,22 +178,25 @@ normalize_basic_privacy_level <- function(privacy_level) {
 #' @description Simplified version for users who just want quick results
 #'
 #' @param transcript_file Path to transcript file
-#' @return Analysis results
+#' @param output_dir Optional output directory. When `NULL`, no files or
+#'   directories are created.
+#' @return The named analysis list returned by `basic_transcript_analysis()`.
 #' @export
 #' @examples
-#' \dontrun{
-#' # Quick analysis
-#' results <- quick_analysis("transcript.vtt")
-#' }
-quick_analysis <- function(transcript_file) {
+#' transcript_file <- system.file(
+#'   "extdata/test_transcripts/ideal_course_session1.vtt",
+#'   package = "engager"
+#' )
+#' results <- quick_analysis(transcript_file)
+quick_analysis <- function(transcript_file, output_dir = NULL) {
   message("QUICK: Quick Analysis Mode")
   message(paste(rep("=", 25), collapse = ""))
 
   # Use basic workflow with default settings
-  results <- basic_transcript_analysis(transcript_file, "quick_output")
+  results <- basic_transcript_analysis(transcript_file, output_dir)
 
   message("SUCCESS: Quick analysis complete!")
-  message("DIR: Results in: quick_output/")
+  message("DIR: Results: ", if (is.null(output_dir)) "in memory" else output_dir)
 
   results
 }
@@ -175,20 +206,25 @@ quick_analysis <- function(transcript_file) {
 #' @description Process multiple transcript files in one workflow
 #'
 #' @param transcript_files Vector of transcript file paths
-#' @param output_dir Output directory for results
+#' @param output_dir Optional parent output directory. When `NULL` (the
+#'   default), all results are returned in memory without creating directories.
 #' @param privacy_level Privacy protection level
-#' @return List of analysis results for each file
+#' @return A named list keyed by transcript basename. Each element is the
+#'   analysis list returned by `basic_transcript_analysis()` or a list with an
+#'   `error` message when that file could not be processed.
 #' @export
 #' @examples
-#' \dontrun{
-#' # Batch analysis
-#' files <- c("session1.vtt", "session2.vtt", "session3.vtt")
-#' results <- batch_basic_analysis(files, "batch_output")
-#' }
-batch_basic_analysis <- function(transcript_files, output_dir = "batch_output", privacy_level = "high") {
+#' transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
+#' files <- file.path(transcript_dir, c(
+#'   "ideal_course_session1.vtt", "ideal_course_session2.vtt"
+#' ))
+#' results <- batch_basic_analysis(files)
+batch_basic_analysis <- function(transcript_files, output_dir = NULL, privacy_level = "high") {
   if (length(transcript_files) == 0) {
     stop("ERROR: No transcript files provided")
   }
+
+  validate_optional_output_dir(output_dir)
 
   # Validate all files exist
   missing_files <- transcript_files[!file.exists(transcript_files)]
@@ -199,7 +235,7 @@ batch_basic_analysis <- function(transcript_files, output_dir = "batch_output", 
   message("BATCH: Batch Analysis Mode")
   message(paste(rep("=", 25), collapse = ""))
   message("FILE: Files: ", length(transcript_files))
-  message("DIR: Output: ", output_dir)
+  message("DIR: Output: ", if (is.null(output_dir)) "in memory" else output_dir)
   message("PRIVACY: Privacy: ", privacy_level)
   message("")
 
@@ -210,7 +246,7 @@ batch_basic_analysis <- function(transcript_files, output_dir = "batch_output", 
     message("Processing file ", i, "/", length(transcript_files), ": ", basename(file))
 
     # Create subdirectory for each file
-    file_output_dir <- file.path(output_dir, paste0("session_", i))
+    file_output_dir <- if (is.null(output_dir)) NULL else file.path(output_dir, paste0("session_", i))
 
     tryCatch(
       {
@@ -228,7 +264,7 @@ batch_basic_analysis <- function(transcript_files, output_dir = "batch_output", 
   }
 
   message("COMPLETE: Batch analysis complete!")
-  message("RESULTS: Results saved to: ", output_dir)
+  message("RESULTS: Results ", if (is.null(output_dir)) "returned in memory" else paste0("saved to: ", output_dir))
   message("STATS: Successful: ", sum(sapply(results, function(x) is.null(x$error))))
   message("ERROR: Failed: ", sum(sapply(results, function(x) !is.null(x$error))))
 

--- a/R/ux_error_handling.R
+++ b/R/ux_error_handling.R
@@ -9,17 +9,11 @@
 #'
 #' @param expr Expression to evaluate
 #' @param context Context for error message
+#' @return The value of `expr` unchanged when evaluation succeeds. On failure,
+#'   the function raises a rewritten error with recovery guidance.
 #' @export
 #' @examples
-#' \dontrun{
-#' # Wrap any expression with user-friendly error handling
-#' result <- user_friendly_error(
-#'   {
-#'     load_zoom_transcript("nonexistent.vtt")
-#'   },
-#'   "loading transcript"
-#' )
-#' }
+#' result <- user_friendly_error(1 + 1, "adding values")
 user_friendly_error <- function(expr, context = "operation") {
   tryCatch(
     {
@@ -186,7 +180,7 @@ validate_file_argument <- function(file_path, context = "file operation") {
 #' @param create_if_missing Whether to create directory if it doesn't exist
 #' @return TRUE if valid, stops with user-friendly error if invalid
 validate_directory_argument <- function(dir_path, context = "directory operation", create_if_missing = TRUE) {
-  if (missing(dir_path) || is.null(dir_path) || dir_path == "") {
+  if (missing(dir_path) || is.null(dir_path)) {
     stop("ERROR: Directory path is required.\n",
       "TIP: Please provide a valid directory path\n",
       "TIP: Example: 'output' or '/path/to/output'",
@@ -194,10 +188,18 @@ validate_directory_argument <- function(dir_path, context = "directory operation
     )
   }
 
-  if (!is.character(dir_path) || length(dir_path) != 1) {
+  if (!is.character(dir_path) || length(dir_path) != 1L || is.na(dir_path)) {
     stop("ERROR: Directory path must be a single text string.\n",
       "TIP: Example: 'output'\n",
       "TIP: Not: c('dir1', 'dir2')",
+      call. = FALSE
+    )
+  }
+
+  if (!nzchar(trimws(dir_path))) {
+    stop("ERROR: Directory path is required.\n",
+      "TIP: Please provide a valid directory path\n",
+      "TIP: Example: 'output' or '/path/to/output'",
       call. = FALSE
     )
   }
@@ -224,12 +226,11 @@ validate_directory_argument <- function(dir_path, context = "directory operation
 #' @description Provides specific recovery suggestions based on error type
 #'
 #' @param error_type Type of error encountered
+#' @return Invisibly `NULL`; called for its recovery guidance printed to the console.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_error_recovery("file_not_found")
 #' show_error_recovery("permission_denied")
-#' }
 show_error_recovery <- function(error_type) {
   switch(error_type,
     "file_not_found" = {

--- a/R/ux_guidance_system.R
+++ b/R/ux_guidance_system.R
@@ -6,11 +6,10 @@
 #' Show getting started guide
 #'
 #' @description Displays a comprehensive getting started guide for new users
+#' @return Invisibly `NULL`; called for its formatted console guide.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_getting_started()
-#' }
 show_getting_started <- function() {
   cat("
 Getting Started with engager
@@ -21,10 +20,11 @@ BASIC WORKFLOW (5 steps):
 2. process_zoom_transcript() - Clean and prepare data
 3. analyze_transcripts() - Calculate engagement metrics
 4. plot_users() - Create charts and graphs
-5. write_metrics() - Save your results
+5. write_metrics(..., path = 'your/output.csv') - Save to an explicit path
 
 QUICK START (Recommended for new users):
    results <- basic_transcript_analysis('your_file.vtt')
+   # To export, supply output_dir = 'your/output/directory'
 
 STEP-BY-STEP WORKFLOW:
    transcript <- load_zoom_transcript('your_file.vtt')
@@ -35,7 +35,7 @@ STEP-BY-STEP WORKFLOW:
 
 BATCH PROCESSING:
    files <- c('session1.vtt', 'session2.vtt')
-   results <- batch_basic_analysis(files, 'output/')
+   results <- batch_basic_analysis(files, output_dir = 'output/')
 
 NEED HELP?
    - show_available_functions() - See functions at your level
@@ -57,12 +57,11 @@ MORE RESOURCES:
 #' Show help for specific function
 #'
 #' @param function_name Name of function to get help for
+#' @return Invisibly `NULL`; called for its formatted console help.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_function_help("load_zoom_transcript")
 #' show_function_help("basic_transcript_analysis")
-#' }
 show_function_help <- function(function_name) {
   # Check if function exists
   if (!exists(function_name, envir = asNamespace("engager"))) {
@@ -114,14 +113,14 @@ show_function_help <- function(function_name) {
     switch(function_name,
       "basic_transcript_analysis" = {
         cat("   results <- basic_transcript_analysis('transcript.vtt')\n")
-        cat("   results <- basic_transcript_analysis('transcript.vtt', 'output/', 'medium')\n")
+        cat("   results <- basic_transcript_analysis('transcript.vtt', output_dir = 'output/', privacy_level = 'medium')\n")
       },
       "quick_analysis" = {
         cat("   results <- quick_analysis('transcript.vtt')\n")
       },
       "batch_basic_analysis" = {
         cat("   files <- c('session1.vtt', 'session2.vtt')\n")
-        cat("   results <- batch_basic_analysis(files, 'output/')\n")
+        cat("   results <- batch_basic_analysis(files, output_dir = 'output/')\n")
       }
     )
   }
@@ -129,18 +128,18 @@ show_function_help <- function(function_name) {
 
 #' Show workflow help and templates
 #'
+#' @return Invisibly `NULL`; called for its formatted console guide.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_workflow_help()
-#' }
 show_workflow_help <- function() {
   cat("
 Available Workflows
 =====================
 
 Basic Workflow (Recommended for new users):
-   results <- basic_transcript_analysis('file.vtt', 'output/')
+   results <- basic_transcript_analysis('file.vtt')
+   # Supply output_dir explicitly when files should be written.
 
 QUICK: Quick Workflow (Fastest):
    results <- quick_analysis('file.vtt')
@@ -154,7 +153,8 @@ RESULTS: Step-by-Step Workflow (Full control):
 
 Batch Workflow (Multiple files):
    files <- c('session1.vtt', 'session2.vtt', 'session3.vtt')
-   results <- batch_basic_analysis(files, 'output/')
+   results <- batch_basic_analysis(files)
+   # Supply output_dir explicitly when files should be written.
 
 Advanced Workflows:
    - Use set_ux_level('intermediate') to see more options
@@ -168,11 +168,10 @@ TIP: Need help finding the right workflow?
 
 #' Show privacy and ethics guidance
 #'
+#' @return Invisibly `NULL`; called for its formatted console guide.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_privacy_guidance()
-#' }
 show_privacy_guidance <- function() {
   cat("
 Privacy & Ethics Guidance
@@ -185,7 +184,7 @@ Privacy Protection (Enabled by Default):
 
 TOOLS: Privacy Functions:
    - ensure_privacy() - Apply privacy protection
-   - write_metrics() - Export masked metrics without raw comments by default
+   - write_metrics(data, path = 'your/output.csv') - Export masked metrics without raw comments by default
    - privacy_audit() - Check privacy risks
    - review_privacy_risks() - privacy review
 
@@ -210,11 +209,10 @@ Privacy Questions?
 
 #' Show troubleshooting guide
 #'
+#' @return Invisibly `NULL`; called for its formatted console guide.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_troubleshooting()
-#' }
 show_troubleshooting <- function() {
   cat("
 TOOLS: Troubleshooting Guide

--- a/R/ux_interactive_help.R
+++ b/R/ux_interactive_help.R
@@ -8,13 +8,12 @@
 #' @description Helps users find the right function based on what they want to do
 #'
 #' @param task Description of what user wants to do
+#' @return Invisibly `NULL`; called for its function suggestions printed to the console.
 #' @export
 #' @examples
-#' \dontrun{
 #' find_function_for_task("load transcript file")
 #' find_function_for_task("create visualizations")
 #' find_function_for_task("export results")
-#' }
 find_function_for_task <- function(task) {
   if (missing(task) || is.null(task) || task == "") {
     cat("What would you like to do? Please describe your task.\n")
@@ -64,7 +63,7 @@ find_function_for_task <- function(task) {
   # Export functions
   if (grepl("export|save|output|write|download", task_lower)) {
     cat("Exporting Results:\n")
-    cat("   - write_metrics() - Export privacy-processed metrics to CSV\n")
+    cat("   - write_metrics(data, path = 'your/output.csv') - Export privacy-processed metrics to CSV\n")
     cat("   - write_unresolved() - Export unresolved-name review data\n")
     cat("   - generate_privacy_review_report() - Write a privacy review report\n\n")
   }
@@ -73,7 +72,7 @@ find_function_for_task <- function(task) {
   if (grepl("privacy|protect|anonymize|mask|secure", task_lower)) {
     cat("Privacy Protection:\n")
     cat("   - ensure_privacy() - Apply privacy protection to data\n")
-    cat("   - write_metrics() - Export masked metrics without raw comments by default\n")
+    cat("   - write_metrics(data, path = 'your/output.csv') - Export masked metrics without raw comments by default\n")
     cat("   - privacy_audit() - Check privacy risks\n")
     cat("   - anonymize_educational_data() - Transform recognized identifier columns\n")
     cat("   - review_privacy_risks() - Run a technical privacy review\n\n")
@@ -111,11 +110,10 @@ find_function_for_task <- function(task) {
 
 #' Show function categories and counts
 #'
+#' @return Invisibly `NULL`; called for its category summary printed to the console.
 #' @export
 #' @examples
-#' \dontrun{
 #' show_function_categories()
-#' }
 show_function_categories <- function() {
   cat("RESULTS: Function Categories Overview\n")
   cat(paste(rep("=", 35), collapse = ""), "\n\n")
@@ -154,13 +152,12 @@ show_function_categories <- function() {
 #' @description Provides intelligent function recommendations based on user context
 #'
 #' @param context User's current context or situation
+#' @return Invisibly `NULL`; called for its recommendations printed to the console.
 #' @export
 #' @examples
-#' \dontrun{
 #' get_smart_recommendations("new user")
 #' get_smart_recommendations("batch processing")
 #' get_smart_recommendations("privacy concerns")
-#' }
 get_smart_recommendations <- function(context) {
   if (missing(context) || is.null(context) || context == "") {
     cat("What's your situation? Please describe your context.\n")
@@ -186,7 +183,7 @@ get_smart_recommendations <- function(context) {
 
   if (grepl("batch|multiple|several|many", context_lower)) {
     cat("Batch Processing Solutions:\n")
-    cat("   1. batch_basic_analysis(files, 'output/') - Process multiple files\n")
+    cat("   1. batch_basic_analysis(files, output_dir = 'output/') - Process multiple files\n")
     cat("   2. summarize_transcript_files() - Summarize multiple transcripts\n\n")
   }
 
@@ -206,7 +203,7 @@ get_smart_recommendations <- function(context) {
 
   if (grepl("export|save|output|download|share", context_lower)) {
     cat("Export & Sharing:\n")
-    cat("   1. write_metrics() - Export privacy-processed metrics to CSV\n")
+    cat("   1. write_metrics(data, path = 'your/output.csv') - Export privacy-processed metrics to CSV\n")
     cat("   2. write_unresolved() - Unresolved-name review CSV\n")
     cat("   3. generate_privacy_review_report() - Privacy review report\n\n")
   }

--- a/R/ux_visibility_system.R
+++ b/R/ux_visibility_system.R
@@ -6,16 +6,14 @@
 #' Get visible functions for user experience level
 #'
 #' @param level User experience level: "basic", "intermediate", "advanced", "expert"
-#' @return Vector of function names visible at this level
+#' @return A character vector of exported function names visible at `level`.
 #' @export
 #' @examples
-#' \dontrun{
 #' # Get functions visible to basic users
 #' basic_functions <- get_visible_functions("basic")
 #'
 #' # Get functions visible to intermediate users
 #' intermediate_functions <- get_visible_functions("intermediate")
-#' }
 get_visible_functions <- function(level = "basic") {
   switch(level,
     "basic" = UX_ESSENTIAL_FUNCTIONS,
@@ -29,15 +27,16 @@ get_visible_functions <- function(level = "basic") {
 #' Set user experience level
 #'
 #' @param level User experience level: "basic", "intermediate", "advanced", "expert"
+#' @return Invisibly, the selected experience level as a character scalar.
 #' @export
 #' @examples
-#' \dontrun{
+#' old_ux_level <- getOption("zoomstudentengagement.ux_level")
 #' # Set to basic level (5 essential functions)
 #' set_ux_level("basic")
 #'
 #' # Set to intermediate level (15 functions)
 #' set_ux_level("intermediate")
-#' }
+#' options(zoomstudentengagement.ux_level = old_ux_level)
 set_ux_level <- function(level = "basic") {
   valid_levels <- c("basic", "intermediate", "advanced", "expert")
   if (!level %in% valid_levels) {
@@ -59,12 +58,11 @@ set_ux_level <- function(level = "basic") {
 
 #' Get current user experience level
 #'
-#' @return Current UX level
+#' @return A character scalar containing the configured experience level, or
+#'   `"basic"` when no level has been configured. This function takes no arguments.
 #' @export
 #' @examples
-#' \dontrun{
 #' current_level <- get_ux_level()
-#' }
 get_ux_level <- function() {
   getOption("zoomstudentengagement.ux_level", "basic")
 }
@@ -72,15 +70,14 @@ get_ux_level <- function() {
 #' Show functions available at current UX level
 #'
 #' @param level User experience level (optional, uses current level if not specified)
+#' @return Invisibly `NULL`; called for its formatted console output.
 #' @export
 #' @examples
-#' \dontrun{
 #' # Show functions at current level
 #' show_available_functions()
 #'
 #' # Show functions at specific level
 #' show_available_functions("intermediate")
-#' }
 show_available_functions <- function(level = NULL) {
   if (is.null(level)) {
     level <- get_ux_level()

--- a/R/validate_privacy_compliance.R
+++ b/R/validate_privacy_compliance.R
@@ -15,7 +15,8 @@
 #' @param stop_on_violation Whether to stop processing if violations are found.
 #'   Defaults to TRUE for maximum privacy protection.
 #'
-#' @return `TRUE` when the technical check finds no configured real names.
+#' @return The logical scalar `TRUE` when the technical check finds no configured
+#'   real names. The function raises an error instead when a blocking exposure is found.
 #' @export
 #' @examples
 #' # Validate privacy compliance

--- a/R/write_metrics.R
+++ b/R/write_metrics.R
@@ -5,7 +5,8 @@
 #'
 #' @param data A tibble containing the data to write
 #' @param what Type of output: "engagement", "summary", or "session_summary" (default: "engagement")
-#' @param path File path where to write the output
+#' @param path Explicit file path where the output will be written. No default
+#'   path is used.
 #' @param comments_format Deprecated alias for `comments_policy`. Use
 #'   `comments_policy = "count"` or `comments_policy = "text"` instead.
 #'   Retained before `privacy_level` to preserve positional compatibility.
@@ -26,7 +27,7 @@
 write_metrics <- function(
     data = NULL,
     what = c("engagement", "summary", "session_summary"),
-    path = NULL,
+    path,
     comments_format = NULL,
     privacy_level = getOption("engager.privacy_level", "mask"),
     comments_policy = c("auto", "omit", "count", "text")) {
@@ -41,6 +42,10 @@ write_metrics <- function(
 
   if (!tibble::is_tibble(data)) {
     stop("`data` must be a tibble")
+  }
+  if (missing(path) || is.null(path) || !is.character(path) ||
+      length(path) != 1L || is.na(path) || !nzchar(trimws(path))) {
+    stop("`path` must be an explicit non-empty file path", call. = FALSE)
   }
 
   # Process data for export
@@ -183,15 +188,6 @@ flatten_comment_entry <- function(x) {
 
 # Helper function to write processed data to file
 write_processed_data_to_file <- function(export_data, what, path) {
-  # Determine default filename
-  if (is.null(path)) {
-    fname <- switch(what,
-      engagement = "engagement_metrics.csv",
-      summary = "transcripts_summary.csv",
-      session_summary = "transcripts_session_summary.csv"
-    )
-    path <- fname
-  }
   dir_path <- dirname(path)
   if (!dir.exists(dir_path)) {
     dir.create(dir_path, recursive = TRUE)

--- a/R/write_section_names_lookup.R
+++ b/R/write_section_names_lookup.R
@@ -1,31 +1,53 @@
 # Internal function - no documentation needed
 write_section_names_lookup <-
   function(clean_names_df = NULL,
-           data_folder = ".",
+           data_folder = NULL,
            section_names_lookup_file = "section_names_lookup.csv") {
-    if (tibble::is_tibble(clean_names_df) &&
-      file.exists(data_folder)
-    ) {
-      # Use base R operations instead of dplyr to avoid segmentation fault
-      # Group by the specified columns and count occurrences
-      group_cols <- c(
-        "course_section", "day", "time", "course", "section",
-        "preferred_name", "formal_name", "transcript_name", "student_id"
-      )
-
-      # Create a unique identifier for each group
-      clean_names_df$group_id <- apply(clean_names_df[, group_cols], 1, paste, collapse = "|")
-
-      # Get the first row from each group (equivalent to summarise)
-      result <- clean_names_df[!duplicated(clean_names_df$group_id), group_cols, drop = FALSE]
-
-      # Sort by preferred_name and formal_name using base R
-      result <- result[order(result$preferred_name, result$formal_name), , drop = FALSE]
-
-      # Write to CSV
-      readr::write_csv(result, file.path(data_folder, section_names_lookup_file))
-
-      # Return the result tibble
-      return(tibble::as_tibble(result))
+    if (!tibble::is_tibble(clean_names_df)) {
+      return(invisible(NULL))
     }
+
+    if (!is.character(data_folder) || length(data_folder) != 1L ||
+        is.na(data_folder) || !nzchar(trimws(data_folder))) {
+      stop(
+        "`data_folder` must be an explicit non-empty directory path",
+        call. = FALSE
+      )
+    }
+    if (!dir.exists(data_folder)) {
+      stop("`data_folder` must name an existing directory", call. = FALSE)
+    }
+    if (!is.character(section_names_lookup_file) ||
+        length(section_names_lookup_file) != 1L ||
+        is.na(section_names_lookup_file) ||
+        !nzchar(trimws(section_names_lookup_file)) ||
+        section_names_lookup_file %in% c(".", "..") ||
+        grepl("[/\\\\]", section_names_lookup_file)) {
+      stop(
+        "`section_names_lookup_file` must be a non-empty file name",
+        call. = FALSE
+      )
+    }
+
+    # Use base R operations instead of dplyr to avoid segmentation fault
+    # Group by the specified columns and count occurrences
+    group_cols <- c(
+      "course_section", "day", "time", "course", "section",
+      "preferred_name", "formal_name", "transcript_name", "student_id"
+    )
+
+    # Create a unique identifier for each group
+    clean_names_df$group_id <- apply(clean_names_df[, group_cols], 1, paste, collapse = "|")
+
+    # Get the first row from each group (equivalent to summarise)
+    result <- clean_names_df[!duplicated(clean_names_df$group_id), group_cols, drop = FALSE]
+
+    # Sort by preferred_name and formal_name using base R
+    result <- result[order(result$preferred_name, result$formal_name), , drop = FALSE]
+
+    # Write to CSV
+    readr::write_csv(result, file.path(data_folder, section_names_lookup_file))
+
+    # Return the result tibble
+    return(tibble::as_tibble(result))
   }

--- a/R/write_transcripts_session_summary.R
+++ b/R/write_transcripts_session_summary.R
@@ -1,11 +1,25 @@
 # Internal function - no documentation needed
 write_transcripts_session_summary <-
   function(transcripts_session_summary_df = NULL,
-           data_folder = ".",
+           data_folder = NULL,
            transcripts_session_summary_file = "transcripts_session_summary.csv") {
     if (!tibble::is_tibble(transcripts_session_summary_df)) {
       return(invisible(NULL))
     }
-    path <- paste0(data_folder, "/", transcripts_session_summary_file)
+    if (is.null(data_folder) || !is.character(data_folder) ||
+        length(data_folder) != 1L || is.na(data_folder) ||
+        !nzchar(trimws(data_folder))) {
+      stop("`data_folder` must be supplied to write the session summary", call. = FALSE)
+    }
+    if (!is.character(transcripts_session_summary_file) ||
+        length(transcripts_session_summary_file) != 1L ||
+        is.na(transcripts_session_summary_file) ||
+        !nzchar(trimws(transcripts_session_summary_file))) {
+      stop(
+        "`transcripts_session_summary_file` must be one non-empty file name",
+        call. = FALSE
+      )
+    }
+    path <- file.path(data_folder, transcripts_session_summary_file)
     write_metrics(transcripts_session_summary_df, what = "session_summary", path = path)
   }

--- a/R/write_transcripts_summary.R
+++ b/R/write_transcripts_summary.R
@@ -1,11 +1,22 @@
 # Internal function - no documentation needed
 write_transcripts_summary <-
   function(transcripts_summary_df = NULL,
-           data_folder = ".",
+           data_folder = NULL,
            transcripts_summary_file = "transcripts_summary.csv") {
     if (!tibble::is_tibble(transcripts_summary_df)) {
       return(invisible(NULL))
     }
-    path <- paste0(data_folder, "/", transcripts_summary_file)
+    if (is.null(data_folder) || !is.character(data_folder) ||
+        length(data_folder) != 1L || is.na(data_folder) ||
+        !nzchar(trimws(data_folder))) {
+      stop("`data_folder` must be supplied to write the summary", call. = FALSE)
+    }
+    if (!is.character(transcripts_summary_file) ||
+        length(transcripts_summary_file) != 1L ||
+        is.na(transcripts_summary_file) ||
+        !nzchar(trimws(transcripts_summary_file))) {
+      stop("`transcripts_summary_file` must be one non-empty file name", call. = FALSE)
+    }
+    path <- file.path(data_folder, transcripts_summary_file)
     write_metrics(transcripts_summary_df, what = "summary", path = path)
   }

--- a/R/write_unresolved.R
+++ b/R/write_unresolved.R
@@ -11,13 +11,21 @@
 #' @param path Output file path.
 #' @param include_raw Logical; include raw names if `TRUE` and allowed.
 #' @param overwrite Logical; overwrite existing file if `TRUE`.
-#' @return Invisibly, the path written.
+#' @return Invisibly, a character scalar containing the path that was written.
 #' @export
 #' @family name-matching
 write_unresolved <- function(unresolved_tbl,
                              path,
                              include_raw = FALSE,
                              overwrite = FALSE) {
+  if (missing(path) || is.null(path) || !is.character(path) ||
+      length(path) != 1L || is.na(path) || !nzchar(trimws(path))) {
+    rlang::abort(
+      message = "path must be one explicit non-empty character path.",
+      class = "engager_schema_error"
+    )
+  }
+
   if (isTRUE(include_raw)) {
     allow_raw <- getOption("engager.allow_raw_name_exports", FALSE)
     if (!isTRUE(allow_raw)) {

--- a/cran/cran-comments.md
+++ b/cran/cran-comments.md
@@ -5,6 +5,8 @@
 - **Package**: engager
 - **Version**: 0.1.1
 - **Submission type**: Update following the initial 0.1.0 release
+- **Current status**: Forward-port validated locally; hosted checks and fresh-user
+  QA pending; not approved for upload
 
 ## Release Summary
 
@@ -19,75 +21,56 @@ This release adds two public functions:
 The release does not add fuzzy matching, generic aggregate anonymization,
 longitudinal student profiles, risk scoring, or new transcript formats.
 
-## Test Environments
+## Candidate Reset
 
-- **Local**: macOS Tahoe 26.5.2, R 4.5.3 (2026-03-11),
-  aarch64-apple-darwin20
-- **GitHub Actions**: Ubuntu, Windows, and macOS with R release — passed
-- **R-devel win-builder**: R Under development (2026-07-16 r90264 ucrt) —
-  0 errors, 0 warnings, 1 note
-- **Secondary remote check**: R-release win-builder, R 4.6.1
-  (2026-06-24 ucrt) — 0 errors, 0 warnings, 1 note
+The earlier 0.1.1 candidate was fully validated before `engager` 0.1.0 was
+accepted by CRAN:
 
-## R CMD Check Results
+- package-content commit:
+  `645112b102f26aeaa57f1ffb8fed68ddb6c14987`;
+- source-tarball SHA-256:
+  `74c309818893c5938f7ee8ba3b623cee2501b390bf7b2b2038682d5f4c54f392`;
+- full tests, installed-package UAT, tarball inspection, hosted checks,
+  R-devel win-builder, and R-release win-builder passed for that artifact.
 
-A network-enabled `R CMD check --no-manual --as-cran` of the exact source
-tarball completed with:
+That artifact is now **superseded for release purposes** because the
+CRAN-requested documentation and explicit-write remediation from 0.1.0 must be
+forward-ported to the 0.1.1 source. The former checksum remains historical
+provenance only and must not be uploaded or described as the current release
+candidate.
 
-- **Errors**: 0
-- **Warnings**: 0
-- **Notes**: 1
+## Forward-Port Boundary
 
-The note is `New submission`. At validation time, version 0.1.0 remained under
-CRAN review and `engager` was not yet present in the CRAN package index.
+The refreshed source must:
 
-Both win-builder checks reported the same single incoming-feasibility note:
-`New submission`, with `reviewable` listed as a possibly misspelled word.
-`reviewable` is an intentional English word describing the package's exact
-name-matching output and review workflow.
+- preserve the exact 37-function 0.1.1 export allowlist;
+- retain the approved multi-session attendance and report schemas;
+- make beginner, quick, and batch analysis read-only by default;
+- require explicit caller-selected destinations for file-writing operations;
+- contain runnable examples and complete argument and return documentation;
+- use only bundled synthetic fixtures and temporary validation destinations.
 
-The canonical sandboxed local validator also passed with 0 errors, 0 warnings,
-and two environment-only notes: incoming URL checks were unavailable without
-network access, and the current time could not be verified. The network-enabled
-check above verified URLs and timestamps successfully.
-
-## Reverse Dependencies
-
-- None at candidate validation time; the package was not yet published on CRAN.
-
-## Validation Details
-
-- The full test suite passes with 0 failures, 67 expected warning-path
-  assertions, and 5 documented skips. Four skips are empty diagnostic
-  placeholders; one covers an internal empty-session-mapping edge case.
-- Installed-package UAT installs the source tarball into an isolated library
-  and exercises the complete 37-function export allowlist, beginner and batch
-  workflows, exact roster matching, three-session attendance analysis,
-  aggregate-default reporting, explicitly masked participant reporting,
-  identifier transformations, plots, exports, privacy review, and installed
-  vignettes.
-- UAT scans generated attendance reports and other exported artifacts for raw
-  synthetic roster identifiers, transcript text, and source paths.
-- Complete supported-export statement coverage is 86.22%, above the declared
-  85% floor; overall package coverage is 88.97%.
-- The release tarball contains 288 entries. Inspection found no `.git` pointer,
-  project-only directories, UAT output, nested archives, local libraries,
-  backups, or private transcript/roster paths.
-- Candidate package-content commit:
-  `645112b102f26aeaa57f1ffb8fed68ddb6c14987`.
-- Candidate source-tarball SHA-256:
-  `74c309818893c5938f7ee8ba3b623cee2501b390bf7b2b2038682d5f4c54f392`.
+The forward-port adds no feature, dependency, export, transcript format,
+privacy claim, or legal or institutional compliance determination.
 
 ## Validation Status
 
-- [x] Full tests pass with no failures
-- [x] Network-enabled local `R CMD check --as-cran` is 0 errors, 0 warnings,
-      and 1 explained note
-- [x] Generated documentation is current
-- [x] Source tarball builds, installs, and passes hygiene inspection
-- [x] Installed-package UAT passes
-- [x] Export allowlist and supported-export coverage contract pass
-- [x] Required hosted checks pass at the exact release head
-- [x] R-devel win-builder completes
-- [x] Secondary remote check completes
-- [ ] Maintainer approves the exact candidate checksum for promotion
+- [x] Generated documentation is current and the export allowlist is exactly 37
+      functions
+- [x] Full tests pass with no failures (68 expected warning-path assertions and
+      5 documented skips)
+- [x] Local `R CMD check --as-cran` completes with no errors or warnings and
+      only explained notes
+- [x] Default workflows create no files or directories without explicit paths
+- [x] Explicit temporary destinations produce the expected artifacts
+- [x] Source tarball builds and passes hygiene inspection (289 entries; no
+      prohibited project, local, nested-archive, or generated artifacts)
+- [x] Installed-package UAT passes, including attendance and reporting
+- [ ] Required hosted Linux, Windows, macOS, `R-CMD-check`, and `Coverage` pass
+- [ ] Fresh-user QA passes for the refreshed artifact
+- [ ] Current R-devel and secondary remote checks pass near the release window
+- [ ] A new exact source commit and SHA-256 are recorded
+- [ ] Maintainer approves the exact refreshed checksum for promotion
+
+No GO disposition, CRAN upload, tag, GitHub release, or release promotion is
+authorized by this reset record.

--- a/man/analyze_transcripts.Rd
+++ b/man/analyze_transcripts.Rd
@@ -18,10 +18,12 @@ analyze_transcripts(
 
 \item{write}{Whether to write results to file (default: FALSE)}
 
-\item{output_path}{Path for output file (defaults to "engagement_metrics.csv")}
+\item{output_path}{Explicit path for the output file when \code{write = TRUE}.}
 }
 \value{
-Data frame with engagement metrics
+A tibble with speaker-level engagement metrics for the discovered
+transcript files. When \code{write = TRUE}, the same metrics are also written
+to \code{output_path} after export privacy policies are applied.
 }
 \description{
 Convenience wrapper to process a set of \code{.transcript.vtt} files from a folder,

--- a/man/anonymize_educational_data.Rd
+++ b/man/anonymize_educational_data.Rd
@@ -28,7 +28,8 @@ identifiers.}
 no effect for supported version 0.1.0 methods.}
 }
 \value{
-Data frame with recognized structured identifier columns transformed.
+A data frame of the same row shape as \code{data}, with recognized
+structured identifier columns transformed by the selected method.
 Missing and blank identifiers remain missing or blank. These transformations
 do not inspect free text and do not establish that a data set is anonymous or
 compliant with legal or institutional requirements.

--- a/man/audit_ethical_usage.Rd
+++ b/man/audit_ethical_usage.Rd
@@ -27,15 +27,4 @@ Audit report with ethical usage analysis
 Analyzes usage patterns to detect potential ethical concerns and
 provides recommendations for improvement.
 }
-\examples{
-\dontrun{
-# Audit usage patterns
-audit <- audit_ethical_usage(
-  function_calls = c("analyze_transcripts", "plot_users", "write_metrics"),
-  data_sizes = c(100, 150, 200),
-  privacy_settings = c("mask", "mask", "privacy_strict"),
-  time_period = 30
-)
-}
-}
 \keyword{internal}

--- a/man/basic_transcript_analysis.Rd
+++ b/man/basic_transcript_analysis.Rd
@@ -6,21 +6,24 @@
 \usage{
 basic_transcript_analysis(
   transcript_file,
-  output_dir = "output",
+  output_dir = NULL,
   privacy_level = "high"
 )
 }
 \arguments{
 \item{transcript_file}{Path to a WebVTT transcript file}
 
-\item{output_dir}{Output directory for results (default: "output")}
+\item{output_dir}{Optional output directory. When \code{NULL} (the default), the
+analysis is returned in memory and no files or directories are created.}
 
 \item{privacy_level}{Privacy protection level: "high" (default), "medium",
 or "low". These map to \code{"privacy_strict"}, \code{"privacy_standard"}, and
 \code{"mask"}, respectively. All three levels mask common identifiers.}
 }
 \value{
-List containing analysis results, plots, and output directory path
+A named list with \code{analysis} (a tibble of speaker metrics), \code{plots}
+(a \code{ggplot} object), \code{output_dir} (the explicit output directory or
+\code{NULL}), \code{transcript_file}, and \code{privacy_level}.
 }
 \description{
 Simplified workflow that guides new users through basic analysis
@@ -28,14 +31,13 @@ of Zoom transcripts with minimal complexity.
 Complete basic transcript analysis workflow
 
 This is the main function for new users. It performs a complete
-analysis workflow in 5 simple steps: load, process, analyze, visualize, and export.
+analysis workflow in five simple steps: load, process, analyze, visualize,
+and either return results in memory or export to an explicit directory.
 }
 \examples{
-\dontrun{
-# Basic workflow for new users
-results <- basic_transcript_analysis("transcript.vtt", "output/")
-
-# With custom privacy level
-results <- basic_transcript_analysis("transcript.vtt", "output/", "medium")
-}
+transcript_file <- system.file(
+  "extdata/test_transcripts/ideal_course_session1.vtt",
+  package = "engager"
+)
+results <- basic_transcript_analysis(transcript_file)
 }

--- a/man/batch_basic_analysis.Rd
+++ b/man/batch_basic_analysis.Rd
@@ -6,27 +6,30 @@
 \usage{
 batch_basic_analysis(
   transcript_files,
-  output_dir = "batch_output",
+  output_dir = NULL,
   privacy_level = "high"
 )
 }
 \arguments{
 \item{transcript_files}{Vector of transcript file paths}
 
-\item{output_dir}{Output directory for results}
+\item{output_dir}{Optional parent output directory. When \code{NULL} (the
+default), all results are returned in memory without creating directories.}
 
 \item{privacy_level}{Privacy protection level}
 }
 \value{
-List of analysis results for each file
+A named list keyed by transcript basename. Each element is the
+analysis list returned by \code{basic_transcript_analysis()} or a list with an
+\code{error} message when that file could not be processed.
 }
 \description{
 Process multiple transcript files in one workflow
 }
 \examples{
-\dontrun{
-# Batch analysis
-files <- c("session1.vtt", "session2.vtt", "session3.vtt")
-results <- batch_basic_analysis(files, "batch_output")
-}
+transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
+files <- file.path(transcript_dir, c(
+  "ideal_course_session1.vtt", "ideal_course_session2.vtt"
+))
+results <- batch_basic_analysis(files)
 }

--- a/man/check_data_retention_policy.Rd
+++ b/man/check_data_retention_policy.Rd
@@ -32,21 +32,4 @@ backward-compatible alias.
 Compares configured date fields with a selected period to support local
 records review. It does not determine or enforce institutional policy.
 }
-\examples{
-\dontrun{
-# Check data retention policy
-sample_data <- tibble::tibble(
-  student_id = c("12345", "67890"),
-  session_date = as.Date(c("2024-01-15", "2024-02-20")),
-  participation_score = c(85, 92)
-)
-
-retention_check <- check_data_retention_policy(
-  sample_data,
-  retention_period = "academic_year",
-  date_column = "session_date"
-)
-print(retention_check$passed)
-}
-}
 \keyword{internal}

--- a/man/consolidate_transcript.Rd
+++ b/man/consolidate_transcript.Rd
@@ -12,11 +12,9 @@ consolidate_transcript(df = NULL, max_pause_sec = 1)
 \item{max_pause_sec}{Maximum pause in seconds between comments to consolidate (default: 1)}
 }
 \value{
-A tibble with consolidated comments
-
-transcript.
-
-consolidate_transcript(df = "NULL")
+A tibble with consecutive comments consolidated by speaker and pause
+threshold, including \code{name}, \code{comment}, \code{start}, \code{end}, \code{duration}, and
+\code{wordcount} columns. Returns \code{NULL} when \code{df} is not a tibble.
 }
 \description{
 Take a tibble containing the comments from a Zoom recording transcript and return a tibble

--- a/man/detect_duplicate_transcripts.Rd
+++ b/man/detect_duplicate_transcripts.Rd
@@ -35,35 +35,6 @@ This function helps clean up transcript datasets by finding files that contain s
 or identical content, which can occur when multiple transcript formats are generated
 for the same recording session.
 }
-\examples{
-\dontrun{
-# Create sample transcript list
-transcript_list <- tibble::tibble(
-  transcript_file = c(
-    "GMT20240115-100000_Recording.transcript.vtt",
-    "GMT20240115-100000_Recording.cc.vtt",
-    "GMT20240116-140000_Recording.transcript.vtt"
-  )
-)
-
-# Detect duplicates in a transcript list
-duplicates <- detect_duplicate_transcripts(transcript_list)
-
-# View duplicate groups
-duplicates$duplicate_groups
-
-# View recommendations
-duplicates$recommendations
-
-# Use different detection method
-content_duplicates <- detect_duplicate_transcripts(
-  transcript_list,
-  method = "content",
-  similarity_threshold = 0.9
-)
-}
-
-}
 \seealso{
 \code{\link{process_zoom_transcript}} for processing individual transcripts,
 \code{\link{summarize_transcript_metrics}} for analyzing transcript content

--- a/man/ensure_privacy.Rd
+++ b/man/ensure_privacy.Rd
@@ -24,15 +24,10 @@ ensure_privacy(
 \item{audit_log}{Whether to log privacy operations (default: TRUE)}
 }
 \value{
-A privacy-processed version of the input object. This is a technical
-masking result, not a legal or institutional compliance determination.
-
-df <- tibble::tibble(
-section = c("A", "A", "B"),
-preferred_name = c("Alice Johnson", "Bob Lee", "Cara Diaz"),
-session_ct = c(3, 5, 2)
-)
-ensure_privacy(df)
+For tabular input, an object with the same data-frame class as \code{x}
+and configured identifier columns transformed according to \code{privacy_level}.
+Non-tabular input is returned unchanged. This is a technical masking result,
+not a legal or institutional compliance determination.
 }
 \description{
 Applies privacy rules to objects before they are returned, written, or
@@ -49,4 +44,13 @@ The default behavior is controlled by the global option
 \code{engager.privacy_level}, which is set to "mask" on package
 load. Pass \code{privacy_level} explicitly for one call, or set the
 \code{engager.privacy_level} option for the current R session.
+}
+\examples{
+df <- tibble::tibble(
+  section = c("A", "A", "B"),
+  preferred_name = c("Alice Johnson", "Bob Lee", "Cara Diaz"),
+  session_ct = c(3, 5, 2)
+)
+ensure_privacy(df)
+
 }

--- a/man/find_function_for_task.Rd
+++ b/man/find_function_for_task.Rd
@@ -9,6 +9,9 @@ find_function_for_task(task)
 \arguments{
 \item{task}{Description of what user wants to do}
 }
+\value{
+Invisibly \code{NULL}; called for its function suggestions printed to the console.
+}
 \description{
 Provides interactive help and function discovery to help users
 find the right functions for their specific tasks.
@@ -17,9 +20,7 @@ Interactive function discovery
 Helps users find the right function based on what they want to do
 }
 \examples{
-\dontrun{
 find_function_for_task("load transcript file")
 find_function_for_task("create visualizations")
 find_function_for_task("export results")
-}
 }

--- a/man/generate_privacy_review_report.Rd
+++ b/man/generate_privacy_review_report.Rd
@@ -27,8 +27,9 @@ generate_privacy_review_report(
 \item{institution_type}{Review context: "educational", "research", or "mixed".}
 }
 \value{
-A list containing report metadata, summary, review results, and
-recommendations.
+A named list containing report metadata, a summary, the underlying
+technical review results, and recommendations. When \code{output_file} is
+supplied, the same report is also serialized there.
 }
 \description{
 Generates a lightweight report from \code{review_privacy_risks()}. The report is

--- a/man/get_smart_recommendations.Rd
+++ b/man/get_smart_recommendations.Rd
@@ -9,13 +9,14 @@ get_smart_recommendations(context)
 \arguments{
 \item{context}{User's current context or situation}
 }
+\value{
+Invisibly \code{NULL}; called for its recommendations printed to the console.
+}
 \description{
 Provides intelligent function recommendations based on user context
 }
 \examples{
-\dontrun{
 get_smart_recommendations("new user")
 get_smart_recommendations("batch processing")
 get_smart_recommendations("privacy concerns")
-}
 }

--- a/man/get_ux_level.Rd
+++ b/man/get_ux_level.Rd
@@ -7,13 +7,12 @@
 get_ux_level()
 }
 \value{
-Current UX level
+A character scalar containing the configured experience level, or
+\code{"basic"} when no level has been configured. This function takes no arguments.
 }
 \description{
 Get current user experience level
 }
 \examples{
-\dontrun{
 current_level <- get_ux_level()
-}
 }

--- a/man/get_visible_functions.Rd
+++ b/man/get_visible_functions.Rd
@@ -10,7 +10,7 @@ get_visible_functions(level = "basic")
 \item{level}{User experience level: "basic", "intermediate", "advanced", "expert"}
 }
 \value{
-Vector of function names visible at this level
+A character vector of exported function names visible at \code{level}.
 }
 \description{
 Manages which functions are visible to users based on experience level
@@ -18,11 +18,9 @@ to implement progressive disclosure and simplify the user interface.
 Get visible functions for user experience level
 }
 \examples{
-\dontrun{
 # Get functions visible to basic users
 basic_functions <- get_visible_functions("basic")
 
 # Get functions visible to intermediate users
 intermediate_functions <- get_visible_functions("intermediate")
-}
 }

--- a/man/load_roster.Rd
+++ b/man/load_roster.Rd
@@ -18,8 +18,19 @@ load_roster(
 \item{strict_errors}{Logical; if TRUE, throw error when file doesn't exist}
 }
 \value{
-A tibble with roster data, filtered by enrolled status if applicable
+A tibble containing the roster rows. When an \code{enrolled} column is
+present, only rows where it is \code{TRUE} are returned. A missing file returns
+an empty tibble unless \code{strict_errors = TRUE}.
 }
 \description{
 Load a roster file
+}
+\examples{
+roster_path <- tempfile(fileext = ".csv")
+readr::write_csv(
+  tibble::tibble(student_id = "S001", preferred_name = "Student One"),
+  roster_path
+)
+roster <- load_roster(roster_path)
+unlink(roster_path)
 }

--- a/man/load_zoom_transcript.Rd
+++ b/man/load_zoom_transcript.Rd
@@ -10,7 +10,9 @@ load_zoom_transcript(transcript_file_path = NULL)
 \item{transcript_file_path}{Path to the transcript file to load}
 }
 \value{
-A tibble containing the transcript data, or NULL if the file is empty
+A tibble with one row per parsed WebVTT cue and columns describing
+speaker name, cue text, start and end times, duration, word count, and
+source transcript. Returns \code{NULL} when the file is empty.
 }
 \description{
 Load a Zoom recording transcript and return tibble containing the comments from a Zoom recording transcript

--- a/man/plot_users.Rd
+++ b/man/plot_users.Rd
@@ -30,7 +30,8 @@ plot_users(
 \item{metrics_lookup_df}{Optional lookup table for metric names (default: NULL)}
 }
 \value{
-A ggplot2 object
+A \code{ggplot} object whose data contains the selected metric and the
+configured privacy-processed participant labels, ready to print or modify.
 }
 \description{
 Unified plotting function for engagement metrics with privacy-aware options.

--- a/man/privacy_audit.Rd
+++ b/man/privacy_audit.Rd
@@ -16,7 +16,9 @@ privacy_audit(
 \item{id_columns}{Vector of column names to check for identifiers (default: common name columns)}
 }
 \value{
-A tibble containing audit results with columns: column, values, non_empty, masked_estimate
+A tibble with one row per detected identifier column and the fields
+\code{column}, \code{values}, \code{non_empty}, and \code{masked_estimate}, summarizing the
+technical masking state of the supplied data.
 }
 \description{
 Summarize which identifier columns were present and how many values were masked.

--- a/man/process_zoom_transcript.Rd
+++ b/man/process_zoom_transcript.Rd
@@ -30,7 +30,9 @@ process_zoom_transcript(
 \item{transcript_df}{Pre-loaded transcript data frame (alternative to transcript_file_path)}
 }
 \value{
-A tibble containing the processed transcript data
+A tibble of processed transcript cues with normalized speaker,
+comment, timing, duration, word-count, and source-file fields. Depending on
+the arguments, adjacent cues may be consolidated and dead-air rows added.
 }
 \description{
 Process a Zoom recording transcript with given parameters and return tibble containing the consolidated and annotated

--- a/man/quick_analysis.Rd
+++ b/man/quick_analysis.Rd
@@ -4,20 +4,24 @@
 \alias{quick_analysis}
 \title{Quick analysis for single transcript file}
 \usage{
-quick_analysis(transcript_file)
+quick_analysis(transcript_file, output_dir = NULL)
 }
 \arguments{
 \item{transcript_file}{Path to transcript file}
+
+\item{output_dir}{Optional output directory. When \code{NULL}, no files or
+directories are created.}
 }
 \value{
-Analysis results
+The named analysis list returned by \code{basic_transcript_analysis()}.
 }
 \description{
 Simplified version for users who just want quick results
 }
 \examples{
-\dontrun{
-# Quick analysis
-results <- quick_analysis("transcript.vtt")
-}
+transcript_file <- system.file(
+  "extdata/test_transcripts/ideal_course_session1.vtt",
+  package = "engager"
+)
+results <- quick_analysis(transcript_file)
 }

--- a/man/review_privacy_risks.Rd
+++ b/man/review_privacy_risks.Rd
@@ -29,8 +29,9 @@ review_privacy_risks(
 \item{audit_log}{Whether to record an in-memory review audit event.}
 }
 \value{
-A list with technical review status, detected fields, recommendations,
-retention check details, and institutional review prompts.
+A named list containing the logical technical review status,
+detected identifier fields, recommendations, retention-review details,
+and institutional review prompts.
 }
 \description{
 Performs a technical privacy review of a data frame by looking for common

--- a/man/safe_name_matching_workflow.Rd
+++ b/man/safe_name_matching_workflow.Rd
@@ -9,8 +9,9 @@ safe_name_matching_workflow(
   roster_data = NULL,
   privacy_level = getOption("engager.privacy_level", "mask"),
   unmatched_names_action = getOption("engager.unmatched_names_action", "stop"),
-  data_folder = ".",
-  section_names_lookup_file = "section_names_lookup.csv"
+  data_folder = NULL,
+  section_names_lookup_file = "section_names_lookup.csv",
+  write_lookup = FALSE
 )
 }
 \arguments{
@@ -27,6 +28,9 @@ Defaults to \code{getOption("engager.unmatched_names_action", "stop")}.}
 \item{data_folder}{Directory containing data files}
 
 \item{section_names_lookup_file}{Name of the section names lookup file}
+
+\item{write_lookup}{Logical; whether the unmatched-name flow may write a
+lookup template to the explicitly selected \code{data_folder}.}
 }
 \value{
 Processed transcript data with privacy-aware name matching applied
@@ -35,18 +39,4 @@ Processed transcript data with privacy-aware name matching applied
 Main workflow function for privacy-supporting name matching. Implements two-stage
 processing: Stage 1 (unmasked matching in memory) and Stage 2 (privacy masking
 for outputs). Provides configuration-driven behavior for unmatched names.
-}
-\examples{
-# Default behavior (maximum privacy)
-# result <- safe_name_matching_workflow(
-#   transcript_file_path = "transcript.vtt",
-#   roster_data = roster_df
-# )
-#
-# Opt-in for convenience
-# result <- safe_name_matching_workflow(
-#   transcript_file_path = "transcript.vtt",
-#   roster_data = roster_df,
-#   unmatched_names_action = "warn"
-# )
 }

--- a/man/set_ux_level.Rd
+++ b/man/set_ux_level.Rd
@@ -9,15 +9,18 @@ set_ux_level(level = "basic")
 \arguments{
 \item{level}{User experience level: "basic", "intermediate", "advanced", "expert"}
 }
+\value{
+Invisibly, the selected experience level as a character scalar.
+}
 \description{
 Set user experience level
 }
 \examples{
-\dontrun{
+old_ux_level <- getOption("zoomstudentengagement.ux_level")
 # Set to basic level (5 essential functions)
 set_ux_level("basic")
 
 # Set to intermediate level (15 functions)
 set_ux_level("intermediate")
-}
+options(zoomstudentengagement.ux_level = old_ux_level)
 }

--- a/man/show_available_functions.Rd
+++ b/man/show_available_functions.Rd
@@ -9,15 +9,16 @@ show_available_functions(level = NULL)
 \arguments{
 \item{level}{User experience level (optional, uses current level if not specified)}
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console output.
+}
 \description{
 Show functions available at current UX level
 }
 \examples{
-\dontrun{
 # Show functions at current level
 show_available_functions()
 
 # Show functions at specific level
 show_available_functions("intermediate")
-}
 }

--- a/man/show_error_recovery.Rd
+++ b/man/show_error_recovery.Rd
@@ -9,12 +9,13 @@ show_error_recovery(error_type)
 \arguments{
 \item{error_type}{Type of error encountered}
 }
+\value{
+Invisibly \code{NULL}; called for its recovery guidance printed to the console.
+}
 \description{
 Provides specific recovery suggestions based on error type
 }
 \examples{
-\dontrun{
 show_error_recovery("file_not_found")
 show_error_recovery("permission_denied")
-}
 }

--- a/man/show_function_categories.Rd
+++ b/man/show_function_categories.Rd
@@ -6,11 +6,12 @@
 \usage{
 show_function_categories()
 }
+\value{
+Invisibly \code{NULL}; called for its category summary printed to the console.
+}
 \description{
 Show function categories and counts
 }
 \examples{
-\dontrun{
 show_function_categories()
-}
 }

--- a/man/show_function_help.Rd
+++ b/man/show_function_help.Rd
@@ -9,12 +9,13 @@ show_function_help(function_name)
 \arguments{
 \item{function_name}{Name of function to get help for}
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console help.
+}
 \description{
 Show help for specific function
 }
 \examples{
-\dontrun{
 show_function_help("load_zoom_transcript")
 show_function_help("basic_transcript_analysis")
-}
 }

--- a/man/show_getting_started.Rd
+++ b/man/show_getting_started.Rd
@@ -6,6 +6,9 @@
 \usage{
 show_getting_started()
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console guide.
+}
 \description{
 Provides contextual help and guidance for users to navigate
 the package effectively and find the right functions for their tasks.
@@ -14,7 +17,5 @@ Show getting started guide
 Displays a comprehensive getting started guide for new users
 }
 \examples{
-\dontrun{
 show_getting_started()
-}
 }

--- a/man/show_privacy_guidance.Rd
+++ b/man/show_privacy_guidance.Rd
@@ -6,11 +6,12 @@
 \usage{
 show_privacy_guidance()
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console guide.
+}
 \description{
 Show privacy and ethics guidance
 }
 \examples{
-\dontrun{
 show_privacy_guidance()
-}
 }

--- a/man/show_troubleshooting.Rd
+++ b/man/show_troubleshooting.Rd
@@ -6,11 +6,12 @@
 \usage{
 show_troubleshooting()
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console guide.
+}
 \description{
 Show troubleshooting guide
 }
 \examples{
-\dontrun{
 show_troubleshooting()
-}
 }

--- a/man/show_workflow_help.Rd
+++ b/man/show_workflow_help.Rd
@@ -6,11 +6,12 @@
 \usage{
 show_workflow_help()
 }
+\value{
+Invisibly \code{NULL}; called for its formatted console guide.
+}
 \description{
 Show workflow help and templates
 }
 \examples{
-\dontrun{
 show_workflow_help()
-}
 }

--- a/man/summarize_transcript_files.Rd
+++ b/man/summarize_transcript_files.Rd
@@ -30,19 +30,23 @@ summarize_transcript_files(
 \item{duplicate_method}{Method for duplicate detection: "hybrid", "content", or "metadata" (default: "hybrid")}
 }
 \value{
-A tibble containing summarized transcript metrics
+A tibble of speaker-level metrics combined across the requested
+transcript files. Metadata columns supplied with \code{transcript_file_names}
+are retained in the result.
 }
 \description{
 Summarize multiple transcript files and return aggregated metrics. If a tibble with additional columns beyond 'transcript_file' is provided, all metadata columns will be preserved in the output.
 }
 \examples{
-# Create sample transcript file names
+transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
 transcript_files <- c(
-  "GMT20240115-100000_Recording.transcript.vtt",
-  "GMT20240116-140000_Recording.transcript.vtt"
+  "ideal_course_session1.vtt",
+  "ideal_course_session2.vtt"
 )
-
-# Summarize transcript files
-summary <- summarize_transcript_files(transcript_file_names = transcript_files)
+summary <- summarize_transcript_files(
+  transcript_file_names = transcript_files,
+  data_folder = transcript_dir,
+  transcripts_folder = "."
+)
 
 }

--- a/man/summarize_transcript_metrics.Rd
+++ b/man/summarize_transcript_metrics.Rd
@@ -37,8 +37,9 @@ summarize_transcript_metrics(
 }
 \value{
 A tibble with one row per speaker (and source transcript when
-present), containing participation totals such as duration, word count,
-session count, and the configured comment representation.
+present). The \code{n} column counts processed cue/comment segments; other
+columns contain total speaking duration, word count, percentage measures,
+words per minute, and the configured comment representation.
 }
 \description{
 Process a Zoom recording transcript and return summary metrics by speaker

--- a/man/summarize_transcript_metrics.Rd
+++ b/man/summarize_transcript_metrics.Rd
@@ -36,7 +36,9 @@ summarize_transcript_metrics(
 \item{comments_format}{Format for comments: "list", "text", or "count" (default: "list")}
 }
 \value{
-A tibble containing summary metrics by speaker
+A tibble with one row per speaker (and source transcript when
+present), containing participation totals such as duration, word count,
+session count, and the configured comment representation.
 }
 \description{
 Process a Zoom recording transcript and return summary metrics by speaker

--- a/man/user_friendly_error.Rd
+++ b/man/user_friendly_error.Rd
@@ -11,6 +11,10 @@ user_friendly_error(expr, context = "operation")
 
 \item{context}{Context for error message}
 }
+\value{
+The value of \code{expr} unchanged when evaluation succeeds. On failure,
+the function raises a rewritten error with recovery guidance.
+}
 \description{
 Provides helpful error messages and recovery guidance to help
 users understand and resolve issues quickly.
@@ -19,13 +23,5 @@ User-friendly error wrapper
 Wraps expressions with user-friendly error handling
 }
 \examples{
-\dontrun{
-# Wrap any expression with user-friendly error handling
-result <- user_friendly_error(
-  {
-    load_zoom_transcript("nonexistent.vtt")
-  },
-  "loading transcript"
-)
-}
+result <- user_friendly_error(1 + 1, "adding values")
 }

--- a/man/validate_privacy_compliance.Rd
+++ b/man/validate_privacy_compliance.Rd
@@ -26,7 +26,8 @@ common name patterns to detect potential violations.}
 Defaults to TRUE for maximum privacy protection.}
 }
 \value{
-\code{TRUE} when the technical check finds no configured real names.
+The logical scalar \code{TRUE} when the technical check finds no configured
+real names. The function raises an error instead when a blocking exposure is found.
 }
 \description{
 Scans data objects for possible real names when package masking is enabled.

--- a/man/write_metrics.Rd
+++ b/man/write_metrics.Rd
@@ -7,7 +7,7 @@
 write_metrics(
   data = NULL,
   what = c("engagement", "summary", "session_summary"),
-  path = NULL,
+  path,
   comments_format = NULL,
   privacy_level = getOption("engager.privacy_level", "mask"),
   comments_policy = c("auto", "omit", "count", "text")
@@ -18,7 +18,8 @@ write_metrics(
 
 \item{what}{Type of output: "engagement", "summary", or "session_summary" (default: "engagement")}
 
-\item{path}{File path where to write the output}
+\item{path}{Explicit file path where the output will be written. No default
+path is used.}
 
 \item{comments_format}{Deprecated alias for \code{comments_policy}. Use
 \code{comments_policy = "count"} or \code{comments_policy = "text"} instead.

--- a/man/write_unresolved.Rd
+++ b/man/write_unresolved.Rd
@@ -16,7 +16,7 @@ write_unresolved(unresolved_tbl, path, include_raw = FALSE, overwrite = FALSE)
 \item{overwrite}{Logical; overwrite existing file if \code{TRUE}.}
 }
 \value{
-Invisibly, the path written.
+Invisibly, a character scalar containing the path that was written.
 }
 \description{
 By default, writes only hashed columns (no raw names). To include raw

--- a/tests/testthat/test-analyze_transcripts.R
+++ b/tests/testthat/test-analyze_transcripts.R
@@ -78,9 +78,7 @@ cleanup_test_files <- function(test_data) {
 # Helper function to run tests with proper directory setup
 with_test_directory <- function(test_data, test_function) {
   # Change to the base directory so that relative paths work correctly
-  old_wd <- getwd()
-  on.exit(setwd(old_wd), add = TRUE)
-  setwd(test_data$temp_base)
+  withr::local_dir(test_data$temp_base)
 
   # Run the test function
   test_function()
@@ -161,21 +159,20 @@ with_test_directory <- function(test_data, test_function) {
   })
 
   # Test 4: NULL output path handling
-  test_that("analyze_transcripts handles NULL output_path", {
+  test_that("analyze_transcripts rejects NULL output_path without writing", {
     test_data <- create_sample_transcript_files()
     on.exit(cleanup_test_files(test_data))
 
     with_test_directory(test_data, function() {
-      # Test with write = TRUE and NULL output_path
-      result <- analyze_transcripts(
-        transcripts_folder = "transcripts",
-        write = TRUE,
-        output_path = NULL
+      expect_error(
+        analyze_transcripts(
+          transcripts_folder = "transcripts",
+          write = TRUE,
+          output_path = NULL
+        ),
+        "output_path.*supplied"
       )
-
-      expect_s3_class(result, "tbl_df")
-      expect_true(file.exists("engagement_metrics.csv"))
-      unlink("engagement_metrics.csv") # Clean up default file
+      expect_false(file.exists("engagement_metrics.csv"))
     })
   })
 
@@ -204,9 +201,7 @@ Student2: Hi there"
     writeLines(sample_content, file.path(transcripts_dir, "single.transcript.vtt"))
 
     # Change to the base directory so that relative paths work correctly
-    old_wd <- getwd()
-    on.exit(setwd(old_wd), add = TRUE)
-    setwd(temp_base)
+    withr::local_dir(temp_base)
 
     result <- analyze_transcripts("transcripts")
     expect_s3_class(result, "tbl_df")
@@ -505,9 +500,7 @@ Student%d: Response from file %d", i, i, i + 1, i)
     file.copy(sample_transcript, file.path(transcripts_dir, "sample.transcript.vtt"))
 
     # Change to the base directory so that relative paths work correctly
-    old_wd <- getwd()
-    on.exit(setwd(old_wd), add = TRUE)
-    setwd(temp_base)
+    withr::local_dir(temp_base)
 
     # Test the function
     result <- analyze_transcripts("transcripts")
@@ -538,9 +531,7 @@ Student%d: Response from file %d", i, i, i + 1, i)
     file.copy(sample_transcript, file.path(transcripts_dir, "sample.transcript.vtt"))
 
     # Change to the base directory so that relative paths work correctly
-    old_wd <- getwd()
-    on.exit(setwd(old_wd), add = TRUE)
-    setwd(temp_base)
+    withr::local_dir(temp_base)
 
     # Test with write = TRUE to verify privacy compliance
     output_file <- tempfile("privacy_test_output.csv")

--- a/tests/testthat/test-basic_transcript_analysis.R
+++ b/tests/testthat/test-basic_transcript_analysis.R
@@ -139,16 +139,69 @@ test_that("basic privacy levels map to supported masking levels", {
   expect_error(normalize_basic_privacy_level(c("high", "low")), "must be one of")
 })
 
+test_that("beginner workflows reject malformed output directories without writing", {
+  transcript_file <- system.file(
+    "extdata/test_transcripts/ideal_course_session1.vtt",
+    package = "engager"
+  )
+  work_dir <- withr::local_tempdir()
+  withr::local_dir(work_dir)
+  before <- list.files(work_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+
+  invalid_output_dirs <- list(
+    "",
+    " ",
+    NA_character_,
+    character(),
+    c("first", "second"),
+    1
+  )
+
+  for (output_dir in invalid_output_dirs) {
+    expect_error(
+      basic_transcript_analysis(transcript_file, output_dir = output_dir),
+      "output_dir.*non-empty directory path"
+    )
+    expect_error(
+      batch_basic_analysis(transcript_file, output_dir = output_dir),
+      "output_dir.*non-empty directory path"
+    )
+  }
+
+  expect_identical(
+    list.files(work_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
+})
+
+test_that("invalid privacy level does not create an output directory", {
+  transcript_file <- system.file(
+    "extdata/test_transcripts/ideal_course_session1.vtt",
+    package = "engager"
+  )
+  output_root <- withr::local_tempdir()
+  output_dir <- file.path(output_root, "must-not-exist")
+
+  expect_error(
+    basic_transcript_analysis(
+      transcript_file,
+      output_dir = output_dir,
+      privacy_level = "unsupported"
+    ),
+    "privacy_level.*must be one of"
+  )
+  expect_false(dir.exists(output_dir))
+})
+
 test_that("quick_analysis delegates to basic_transcript_analysis", {
   tf <- tempfile(fileext = ".vtt")
   writeLines(c("WEBVTT", "\n", "00:00:00.000 --> 00:00:01.000", "Hello"), tf)
   called <- FALSE
   with_mocked_bindings(
-    basic_transcript_analysis = function(transcript_file, output_dir = "output", privacy_level = "high") {
+    basic_transcript_analysis = function(transcript_file, output_dir = NULL, privacy_level = "high") {
       called <<- TRUE
-      if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
       expect_equal(transcript_file, tf)
-      expect_equal(output_dir, "quick_output")
+      expect_null(output_dir)
       list(
         analysis = tibble::tibble(), plots = list(), output_dir = output_dir,
         transcript_file = transcript_file, privacy_level = privacy_level
@@ -157,7 +210,7 @@ test_that("quick_analysis delegates to basic_transcript_analysis", {
     {
       res <- quick_analysis(tf)
       expect_true(called)
-      expect_equal(res$output_dir, "quick_output")
+      expect_null(res$output_dir)
       expect_equal(res$transcript_file, tf)
     }
   )
@@ -175,8 +228,30 @@ test_that("quick_analysis runs a bundled transcript without source-tree assumpti
   result <- quick_analysis(transcript_file)
 
   expect_s3_class(result$analysis, "tbl_df")
-  expect_true(file.exists(file.path(work_dir, "quick_output", "engagement_metrics.csv")))
+  expect_length(list.files(work_dir, all.files = TRUE, no.. = TRUE), 0)
   expect_equal(getOption("engager.privacy_level"), "mask")
+})
+
+test_that("default beginner and batch workflows do not write", {
+  withr::local_options(engager.privacy_level = "mask")
+  work_dir <- withr::local_tempdir()
+  withr::local_dir(work_dir)
+  transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
+  files <- file.path(
+    transcript_dir,
+    c("ideal_course_session1.vtt", "ideal_course_session2.vtt")
+  )
+  before <- list.files(work_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+
+  basic <- basic_transcript_analysis(files[[1]])
+  batch <- batch_basic_analysis(files)
+
+  expect_null(basic$output_dir)
+  expect_true(all(vapply(batch, function(x) is.null(x$output_dir), logical(1))))
+  expect_identical(
+    list.files(work_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
 })
 
 test_that("batch_basic_analysis validates and processes multiple files", {
@@ -186,7 +261,7 @@ test_that("batch_basic_analysis validates and processes multiple files", {
 
   called <- 0L
   with_mocked_bindings(
-    basic_transcript_analysis = function(transcript_file, output_dir = "output", privacy_level = "high") {
+    basic_transcript_analysis = function(transcript_file, output_dir = NULL, privacy_level = "high") {
       called <<- called + 1L
       if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
       list(analysis = tibble::tibble(), output_dir = output_dir, transcript_file = transcript_file)

--- a/tests/testthat/test-cran-documentation-contract.R
+++ b/tests/testthat/test-cran-documentation-contract.R
@@ -1,0 +1,174 @@
+test_that("exported documentation has values and internal docs have no examples", {
+  package_root <- normalizePath(test_path("../.."), mustWork = TRUE)
+  namespace_path <- file.path(package_root, "NAMESPACE")
+  man_dir <- file.path(package_root, "man")
+  skip_if_not(file.exists(namespace_path) && dir.exists(man_dir))
+
+  namespace <- readLines(namespace_path, warn = FALSE)
+  export_lines <- grep("^export[(]", namespace, value = TRUE)
+  exports <- substr(export_lines, 8, nchar(export_lines) - 1L)
+  rd_files <- list.files(man_dir, pattern = "[.]Rd$", full.names = TRUE)
+
+  documented_exports <- character()
+  internal_examples <- character()
+  missing_values <- character()
+  missing_arguments <- character()
+
+  for (rd_file in rd_files) {
+    rd <- readLines(rd_file, warn = FALSE)
+    alias_lines <- rd[startsWith(rd, "\\alias{")]
+    aliases <- substr(alias_lines, 8, nchar(alias_lines) - 1L)
+    exported_aliases <- intersect(exports, aliases)
+    has_examples <- any(startsWith(rd, "\\examples{"))
+
+    if (length(exported_aliases) > 0L) {
+      documented_exports <- union(documented_exports, exported_aliases)
+      if (!any(startsWith(rd, "\\value{"))) {
+        missing_values <- union(missing_values, exported_aliases)
+      }
+      rd_text <- paste(rd, collapse = "\n")
+      argument_items <- regmatches(
+        rd_text,
+        gregexpr("\\\\item\\{[^}]+\\}", rd_text, perl = TRUE)
+      )[[1]]
+      documented_arguments <- if (identical(argument_items, "")) {
+        character()
+      } else {
+        sub("^\\\\item\\{([^}]+)\\}$", "\\1", argument_items)
+      }
+      for (exported_alias in exported_aliases) {
+        function_arguments <- names(formals(get(exported_alias, envir = asNamespace("engager"))))
+        missing <- setdiff(function_arguments, documented_arguments)
+        if (length(missing) > 0L) {
+          missing_arguments <- c(
+            missing_arguments,
+            paste0(exported_alias, "(", paste(missing, collapse = ", "), ")")
+          )
+        }
+      }
+    } else if (has_examples) {
+      internal_examples <- c(internal_examples, basename(rd_file))
+    }
+  }
+
+  expect_setequal(documented_exports, exports)
+  expect_length(missing_values, 0)
+  expect_length(missing_arguments, 0)
+  expect_length(internal_examples, 0)
+
+  documentation_text <- paste(
+    unlist(lapply(c(list.files(file.path(package_root, "R"), full.names = TRUE), rd_files),
+      readLines,
+      warn = FALSE
+    )),
+    collapse = "\n"
+  )
+  expect_false(grepl("\\\\dontrun", documentation_text))
+  expect_false(grepl("\\\\donttest", documentation_text))
+})
+
+test_that("generated test artifacts are absent from the package source", {
+  expect_false(file.exists(test_path("test.csv")))
+  expect_false(file.exists(test_path("session_mapping.csv")))
+  expect_false(file.exists(test_path("section_names_lookup.csv")))
+})
+
+test_that("tests do not target literal write destinations or change working directory", {
+  package_root <- normalizePath(test_path("../.."), mustWork = TRUE)
+  test_files <- list.files(
+    file.path(package_root, "tests", "testthat"),
+    pattern = "[.]R$",
+    full.names = TRUE
+  )
+  destination_arguments <- list(
+    "dir.create" = c(path = 1L),
+    "unlink" = c(x = 1L),
+    "file.create" = c(file = 1L),
+    "writeLines" = c(con = 2L),
+    "write.csv" = c(file = 2L),
+    "utils::write.csv" = c(file = 2L),
+    "write.csv2" = c(file = 2L),
+    "utils::write.csv2" = c(file = 2L),
+    "write.table" = c(file = 2L),
+    "utils::write.table" = c(file = 2L),
+    "readr::write_csv" = c(file = 2L),
+    "saveRDS" = c(file = 2L),
+    "file.copy" = c(to = 2L),
+    "file.rename" = c(to = 2L),
+    "ggplot2::ggsave" = c(filename = 1L)
+  )
+
+  call_name <- function(expr) {
+    if (!is.call(expr)) {
+      return(NULL)
+    }
+    head <- expr[[1L]]
+    if (is.symbol(head)) {
+      return(as.character(head))
+    }
+    if (is.call(head) && identical(head[[1L]], as.name("::"))) {
+      return(paste(as.character(head[[2L]]), as.character(head[[3L]]), sep = "::"))
+    }
+    NULL
+  }
+
+  destination_arg <- function(expr, specification) {
+    args <- as.list(expr)[-1L]
+    argument_name <- names(specification)[[1L]]
+    named_position <- match(argument_name, names(args), nomatch = 0L)
+    if (named_position > 0L) {
+      return(args[[named_position]])
+    }
+    position <- unname(specification[[1L]])
+    if (length(args) >= position) args[[position]] else NULL
+  }
+
+  violations <- character()
+  inspect_expression <- function(expr, source_file) {
+    if (!is.call(expr)) {
+      return(invisible(NULL))
+    }
+
+    name <- call_name(expr)
+    if (identical(name, "setwd")) {
+      violations <<- c(violations, paste0(basename(source_file), ": setwd"))
+    }
+    if (!is.null(name) && name %in% names(destination_arguments)) {
+      destination <- destination_arg(expr, destination_arguments[[name]])
+      if (is.character(destination)) {
+        violations <<- c(violations, paste0(basename(source_file), ": ", name))
+      }
+    }
+
+    for (index in seq_along(expr)) {
+      if (identical(expr[[index]], quote(expr = ))) {
+        next
+      }
+      inspect_expression(expr[[index]], source_file)
+    }
+    invisible(NULL)
+  }
+
+  for (test_file in test_files) {
+    expressions <- parse(test_file, keep.source = FALSE)
+    for (expr in expressions) {
+      inspect_expression(expr, test_file)
+    }
+  }
+
+  expect_false(
+    length(unique(violations)) > 0L,
+    info = paste(unique(violations), collapse = ", ")
+  )
+})
+
+test_that("worktree metadata is excluded from source builds", {
+  package_root <- normalizePath(test_path("../.."), mustWork = TRUE)
+  build_ignore_path <- file.path(package_root, ".Rbuildignore")
+  skip_if_not(
+    file.exists(build_ignore_path),
+    ".Rbuildignore is only available in a source checkout"
+  )
+  build_ignore <- readLines(build_ignore_path, warn = FALSE)
+  expect_true(any(build_ignore == "^\\.git$"))
+})

--- a/tests/testthat/test-create_session_mapping.R
+++ b/tests/testthat/test-create_session_mapping.R
@@ -233,10 +233,12 @@ test_that("create_session_mapping handles verbose mode", {
 test_that("create_session_mapping handles comprehensive parameters", {
   zoom_data <- create_zoom_recordings_data()
   course_data <- create_course_info_data()
+  explicit_output <- tempfile(fileext = ".csv")
+  on.exit(unlink(explicit_output), add = TRUE)
 
   param_combinations <- list(
     list(zoom_recordings_df = zoom_data, course_info_df = course_data),
-    list(zoom_recordings_df = zoom_data, course_info_df = course_data, output_file = "test.csv"),
+    list(zoom_recordings_df = zoom_data, course_info_df = course_data, output_file = explicit_output),
     list(zoom_recordings_df = zoom_data, course_info_df = course_data, semester_start_mdy = "Feb 01, 2024"),
     list(zoom_recordings_df = zoom_data, course_info_df = course_data, auto_assign_patterns = list()),
     list(zoom_recordings_df = zoom_data, course_info_df = course_data, interactive = TRUE),

--- a/tests/testthat/test-explicit-write-paths.R
+++ b/tests/testthat/test-explicit-write-paths.R
@@ -1,0 +1,106 @@
+test_that("write-capable helpers reject malformed destinations without side effects", {
+  sandbox <- withr::local_tempdir()
+  withr::local_dir(sandbox)
+  before <- list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+  invalid_paths <- list(NULL, "", " ", NA_character_, character(), c("a", "b"), 1)
+  data <- tibble::tibble(name = "Student_1", wordcount = 1L)
+
+  for (path in invalid_paths) {
+    expect_error(do.call(write_metrics, list(data = data, path = path)))
+    expect_error(do.call(write_unresolved, list(
+      unresolved_tbl = tibble::tibble(),
+      path = path
+    )))
+    expect_error(write_lookup_transactional(data.frame(), path = path))
+  }
+
+  expect_identical(
+    list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
+})
+
+test_that("optional writer destinations reject NA and whitespace before writing", {
+  sandbox <- withr::local_tempdir()
+  withr::local_dir(sandbox)
+  before <- list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+  transcript_dir <- system.file("extdata/test_transcripts", package = "engager")
+  review_data <- tibble::tibble(participant = "Student_1", wordcount = 1L)
+
+  for (path in list(NA_character_, " ")) {
+    expect_error(analyze_transcripts(transcript_dir, write = TRUE, output_path = path))
+    expect_error(create_session_mapping(NULL, NULL, output_file = path))
+    expect_error(generate_privacy_review_report(review_data, output_file = path))
+  }
+
+  expect_identical(
+    list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
+})
+
+test_that("legacy writer helpers require explicit non-empty destinations", {
+  sandbox <- withr::local_tempdir()
+  withr::local_dir(sandbox)
+  before <- list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+  summary_data <- tibble::tibble(name = "Student_1", wordcount = 1L)
+
+  expect_error(load_cancelled_classes(
+    data_folder = " ",
+    write_blank_cancelled_classes = TRUE
+  ))
+  expect_error(load_cancelled_classes(
+    data_folder = sandbox,
+    cancelled_classes_file = " ",
+    write_blank_cancelled_classes = TRUE
+  ))
+  expect_error(prompt_name_matching(
+    "Unmatched Student",
+    data_folder = " ",
+    write_lookup = TRUE
+  ))
+  expect_error(prompt_name_matching(
+    "Unmatched Student",
+    data_folder = sandbox,
+    section_names_lookup_file = NA_character_,
+    write_lookup = TRUE
+  ))
+  expect_error(write_transcripts_summary(summary_data, data_folder = " "))
+  expect_error(write_transcripts_summary(
+    summary_data,
+    data_folder = sandbox,
+    transcripts_summary_file = NA_character_
+  ))
+  expect_error(write_transcripts_session_summary(summary_data, data_folder = " "))
+  expect_error(write_transcripts_session_summary(
+    summary_data,
+    data_folder = sandbox,
+    transcripts_session_summary_file = NA_character_
+  ))
+  expect_error(validate_directory_argument(" "))
+
+  expect_identical(
+    list.files(sandbox, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
+})
+
+test_that("explicit temporary destinations still write expected artifacts", {
+  sandbox <- withr::local_tempdir()
+  metrics_path <- file.path(sandbox, "metrics.csv")
+  report_path <- file.path(sandbox, "privacy.txt")
+  metrics <- tibble::tibble(name = "Student_1", wordcount = 1L)
+
+  expect_s3_class(
+    write_metrics(metrics, path = metrics_path, privacy_level = "mask"),
+    "tbl_df"
+  )
+  report <- generate_privacy_review_report(
+    tibble::tibble(participant = "Student_1", wordcount = 1L),
+    output_file = report_path
+  )
+
+  expect_true(file.exists(metrics_path))
+  expect_true(file.exists(report_path))
+  expect_type(report, "list")
+})

--- a/tests/testthat/test-generate_attendance_report.R
+++ b/tests/testthat/test-generate_attendance_report.R
@@ -155,6 +155,11 @@ test_that("participant report rejects raw or ambiguous detail requests", {
     class = "engager_input_error"
   )
   expect_error(
+    generate_attendance_report(analysis, output_file = NA_character_),
+    "one non-empty character path",
+    class = "engager_input_error"
+  )
+  expect_error(
     generate_attendance_report(
       analysis,
       output_file = file.path(tempfile(), "report.md")

--- a/tests/testthat/test-load_cancelled_classes.R
+++ b/tests/testthat/test-load_cancelled_classes.R
@@ -79,3 +79,10 @@ test_that("load_cancelled_classes creates blank file when write_blank_cancelled_
   # Clean up
   unlink(temp_file)
 })
+
+test_that("load_cancelled_classes requires a destination before writing", {
+  expect_error(
+    load_cancelled_classes(write_blank_cancelled_classes = TRUE),
+    "data_folder.*must be supplied"
+  )
+})

--- a/tests/testthat/test-lookup_merge_utils-comprehensive.R
+++ b/tests/testthat/test-lookup_merge_utils-comprehensive.R
@@ -83,12 +83,13 @@ test_that("conditionally_write_lookup handles different allow_write values", {
 
 test_that("lookup_merge_utils functions handle edge cases", {
   # Test with invalid file paths
-  result1 <- read_lookup_safely("")
-  expect_s3_class(result1, "data.frame")
-  expect_equal(nrow(result1), 0)
+  expect_error(
+    read_lookup_safely(""),
+    "explicit non-empty character path"
+  )
 
   # Test with NULL path (should error)
-  expect_error(read_lookup_safely(NULL), "path must be a single character string")
+  expect_error(read_lookup_safely(NULL), "explicit non-empty character path")
 
   # Test with invalid data types (should error)
   expect_error(write_lookup_transactional("invalid_data", "test.csv"), "invalid 'times' argument")

--- a/tests/testthat/test-no-artifacts.R
+++ b/tests/testthat/test-no-artifacts.R
@@ -6,11 +6,7 @@ test_that("tests do not leave artifacts in working directory", {
   unlink(tmp)
   expect_false(file.exists(tmp))
 
-  # Ensure default output filename used by analyze_transcripts is not present
-  # If present from a prior failure, remove it now to avoid bleed-over
-  if (file.exists("engagement_metrics.csv")) {
-    unlink("engagement_metrics.csv")
-  }
+  # Default analysis must not create this historical output in getwd().
   expect_false(file.exists("engagement_metrics.csv"))
 })
 

--- a/tests/testthat/test-prompt_name_matching.R
+++ b/tests/testthat/test-prompt_name_matching.R
@@ -28,6 +28,7 @@ test_that("prompt_name_matching works correctly", {
         prompt_name_matching(unmatched, data_folder = tempdir()),
         "Found 3 unmatched names that need manual mapping"
       )
+      expect_false(file.exists(file.path(tempdir(), "section_names_lookup.csv")))
     }
   )
 
@@ -59,11 +60,13 @@ test_that("prompt_name_matching works correctly", {
           prompt_name_matching(
             unmatched_names = c("John Doe"),
             data_folder = tf,
-            section_names_lookup_file = "test_lookup.csv"
+            section_names_lookup_file = "test_lookup.csv",
+            write_lookup = TRUE
           )
         },
         "Found 1 unmatched name"
       )
+      unlink(file.path(tf, "test_lookup.csv"))
     }
   )
 })
@@ -84,7 +87,7 @@ test_that("prompt_name_matching validates inputs correctly", {
   # Test invalid data_folder
   expect_error(
     prompt_name_matching(c("test"), data_folder = 123),
-    "data_folder must be a single character string"
+    "data_folder must be NULL or a non-empty character string"
   )
 
   # Test invalid section_names_lookup_file
@@ -97,6 +100,11 @@ test_that("prompt_name_matching validates inputs correctly", {
   expect_error(
     prompt_name_matching(c("test"), include_instructions = "invalid"),
     "include_instructions must be a single logical value"
+  )
+
+  expect_error(
+    prompt_name_matching(c("test"), write_lookup = TRUE),
+    "data_folder.*must be supplied"
   )
 })
 

--- a/tests/testthat/test-safe_name_matching_workflow.R
+++ b/tests/testthat/test-safe_name_matching_workflow.R
@@ -82,7 +82,7 @@ test_that("safe_name_matching_workflow validates inputs correctly", {
   # Test invalid data_folder
   expect_error(
     safe_name_matching_workflow(temp_file, tibble::tibble(), data_folder = 123),
-    "data_folder must be a single character string"
+    "data_folder must be NULL or a non-empty character string"
   )
 
   # Test invalid section_names_lookup_file
@@ -332,25 +332,34 @@ test_that("handle_unmatched_names works correctly", {
   expect_match(err$message, "Guest1")
 
   # Test with warn action
-  captured_unmatched_names <- NULL
-  with_mocked_bindings(
-    prompt_name_matching = function(unmatched_names, ...) {
-      captured_unmatched_names <<- unmatched_names
-      TRUE
-    },
-    {
-      expect_error(
-        handle_unmatched_names(
-          unmatched_names = c("Dr. Smith", "Guest1"),
-          transcript_data = tibble::tibble(speaker = c("Dr. Smith", "Guest1")),
-          unmatched_names_action = "warn",
-          privacy_level = "mask",
-          data_folder = "data",
-          section_names_lookup_file = "test.csv"
-        ),
-        "Please update the name mappings file"
-      )
-    }
+  err <- expect_error(
+    handle_unmatched_names(
+      unmatched_names = c("Dr. Smith", "Guest1"),
+      transcript_data = tibble::tibble(speaker = c("Dr. Smith", "Guest1")),
+      unmatched_names_action = "warn",
+      privacy_level = "mask",
+      data_folder = NULL,
+      section_names_lookup_file = "test.csv"
+    ),
+    class = "engager_name_matching_required"
   )
-  expect_equal(captured_unmatched_names, c("Dr. Smith", "Guest1"))
+  expect_s3_class(err$lookup_template, "data.frame")
+  expect_null(err$lookup_path)
+  expect_match(err$message, "No file was written")
+
+  output_dir <- withr::local_tempdir()
+  err <- expect_error(
+    handle_unmatched_names(
+      unmatched_names = c("Dr. Smith", "Guest1"),
+      transcript_data = tibble::tibble(speaker = c("Dr. Smith", "Guest1")),
+      unmatched_names_action = "warn",
+      privacy_level = "mask",
+      data_folder = output_dir,
+      section_names_lookup_file = "test.csv",
+      write_lookup = TRUE
+    ),
+    class = "engager_name_matching_required"
+  )
+  expect_equal(err$lookup_path, file.path(output_dir, "test.csv"))
+  expect_true(file.exists(err$lookup_path))
 })

--- a/tests/testthat/test-safe_name_matching_workflow_coverage.R
+++ b/tests/testthat/test-safe_name_matching_workflow_coverage.R
@@ -81,7 +81,7 @@ test_that("safe_name_matching_workflow validates inputs correctly", {
   # Test invalid data_folder
   expect_error(
     safe_name_matching_workflow(tmp, tibble::tibble(first_last = "Test", preferred_name = "Test"), data_folder = 123),
-    "data_folder must be a single character string"
+    "data_folder must be NULL or a non-empty character string"
   )
 
   # Test invalid section_names_lookup_file
@@ -228,7 +228,7 @@ test_that("safe_name_matching_workflow handles unmatched names", {
       roster_data = partial_roster,
       unmatched_names_action = "warn"
     ),
-    "Please update the name mappings file"
+    class = "engager_name_matching_required"
   )
 })
 
@@ -651,25 +651,19 @@ test_that("handle_unmatched_names handles different actions", {
     regexp = "Found unmatched names"
   )
 
-  # Test with warn action (mocked to avoid interactive prompts)
-  with_mocked_bindings(
-    prompt_name_matching = function(...) {
-      # Mock implementation that doesn't prompt
-      invisible(NULL)
-    },
-    {
-      expect_error(
-        handle_unmatched_names(
-          unmatched_names = unmatched_names,
-          unmatched_names_action = "warn",
-          privacy_level = "mask",
-          data_folder = ".",
-          section_names_lookup_file = "test.csv"
-        ),
-        regexp = "Please update the name mappings file"
-      )
-    }
+  # Test with warn action and in-memory recovery template.
+  err <- expect_error(
+    handle_unmatched_names(
+      unmatched_names = unmatched_names,
+      transcript_data = transcript_data,
+      unmatched_names_action = "warn",
+      privacy_level = "mask",
+      data_folder = NULL,
+      section_names_lookup_file = "test.csv"
+    ),
+    class = "engager_name_matching_required"
   )
+  expect_s3_class(err$lookup_template, "data.frame")
 })
 
 # Test detect_unmatched_names function

--- a/tests/testthat/test-summarize_transcript_files-duplicates.R
+++ b/tests/testthat/test-summarize_transcript_files-duplicates.R
@@ -1,3 +1,6 @@
+test_root <- withr::local_tempdir()
+test_transcripts_dir <- file.path(test_root, "test_transcripts")
+
 test_that("summarize_transcript_files triggers duplicate diagnostics path (quiet in tests)", {
   # Minimal tibble input (no real files needed)
   tfiles <- tibble::tibble(transcript_file = character())
@@ -17,18 +20,18 @@ test_that("summarize_transcript_files triggers duplicate diagnostics path (quiet
   on.exit(assignInNamespace("detect_duplicate_transcripts", orig, ns = "engager"), add = TRUE)
 
   # Create a fake transcripts folder to pass folder existence check
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
   # Call with deduplicate_content = TRUE to hit the diagnostics branch
   expect_no_error(
     summarize_transcript_files(
       transcript_file_names = tfiles,
-      data_folder = ".",
+      data_folder = test_root,
       transcripts_folder = "test_transcripts",
       deduplicate_content = TRUE,
       duplicate_method = "hybrid"
     )
   )
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-summarize_transcript_files.R
+++ b/tests/testthat/test-summarize_transcript_files.R
@@ -1,3 +1,6 @@
+test_root <- withr::local_tempdir()
+test_transcripts_dir <- file.path(test_root, "test_transcripts")
+
 test_that("summarize_transcript_files summarizes multiple transcript files correctly", {
   # Create a fake transcript list
   transcript_file_names <- tibble::tibble(
@@ -25,31 +28,31 @@ test_that("summarize_transcript_files summarizes multiple transcript files corre
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_s3_class(result, "tbl_df")
   expect_true(all(c("name", "n", "duration", "wordcount", "comments", "n_perc", "duration_perc", "wordcount_perc", "wpm", "transcript_file", "transcript_path", "name_raw") %in% names(result)))
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles empty input", {
   transcript_file_names <- tibble::tibble(transcript_file = character())
-  dir.create("test_transcripts", showWarnings = FALSE)
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_true(is.null(result) || (is.data.frame(result) && nrow(result) == 0))
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles NA transcript_file", {
   transcript_file_names <- tibble::tibble(transcript_file = c(NA, "file2.vtt"))
-  dir.create("test_transcripts", showWarnings = FALSE)
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_true(is.null(result) || (is.data.frame(result) && nrow(result) >= 0))
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files returns NULL for completely invalid input", {
-  result <- summarize_transcript_files(transcript_file_names = NULL, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = NULL, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_null(result)
 })
 
@@ -113,16 +116,16 @@ test_that("summarize_transcript_files validates file name matching", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
   # Warnings are now conditional in test environment, so don't expect them
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
 
   # Should still return a valid result
   expect_s3_class(result, "tbl_df")
   expect_true("transcript_file" %in% names(result))
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles matching file names correctly", {
@@ -153,18 +156,18 @@ test_that("summarize_transcript_files handles matching file names correctly", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
   # Should not warn about mismatched filenames
   expect_no_warning(
-    result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+    result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
   )
 
   # Should return a valid result
   expect_s3_class(result, "tbl_df")
   expect_true("transcript_file" %in% names(result))
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles character vector input", {
@@ -193,14 +196,14 @@ test_that("summarize_transcript_files handles character vector input", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
-  result <- summarize_transcript_files(transcript_file_names = transcript_files, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = transcript_files, data_folder = test_root, transcripts_folder = "test_transcripts")
 
   expect_s3_class(result, "tbl_df")
   expect_true(all(c("name", "n", "duration", "wordcount", "transcript_file", "transcript_path", "name_raw") %in% names(result)))
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles non-existent folder", {
@@ -210,7 +213,7 @@ test_that("summarize_transcript_files handles non-existent folder", {
   )
 
   # Should return NULL when folder doesn't exist
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "non_existent_folder")
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "non_existent_folder")
   expect_null(result)
 })
 
@@ -222,12 +225,12 @@ test_that("summarize_transcript_files handles non-tibble input", {
   )
 
   # Function should return NULL for non-tibble input
-  result <- summarize_transcript_files(transcript_file_names = df_input, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = df_input, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_null(result)
 
   # Test with list input
   list_input <- list(transcript_file = c("file1.vtt", "file2.vtt"))
-  result2 <- summarize_transcript_files(transcript_file_names = list_input, data_folder = ".", transcripts_folder = "test_transcripts")
+  result2 <- summarize_transcript_files(transcript_file_names = list_input, data_folder = test_root, transcripts_folder = "test_transcripts")
   expect_null(result2)
 })
 
@@ -248,9 +251,9 @@ test_that("summarize_transcript_files handles empty results", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
 
   # Should return empty tibble with expected columns
   expect_s3_class(result, "tbl_df")
@@ -260,7 +263,7 @@ test_that("summarize_transcript_files handles empty results", {
     "wordcount_perc", "wpm", "transcript_file", "transcript_path", "name_raw"
   ) %in% names(result)))
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles metadata preservation", {
@@ -294,15 +297,15 @@ test_that("summarize_transcript_files handles metadata preservation", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
 
   expect_s3_class(result, "tbl_df")
   expect_true(all(c("transcript_file", "session_date", "instructor", "course_code") %in% names(result)))
   expect_equal(nrow(result), 4) # 2 files * 2 speakers each
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles NA file names", {
@@ -337,15 +340,15 @@ test_that("summarize_transcript_files handles NA file names", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
-  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = ".", transcripts_folder = "test_transcripts")
+  result <- summarize_transcript_files(transcript_file_names = transcript_file_names, data_folder = test_root, transcripts_folder = "test_transcripts")
 
   expect_s3_class(result, "tbl_df")
   # Should have results for the 2 valid files (4 rows total: 2 files * 2 speakers each)
   expect_equal(nrow(result), 4)
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles names_to_exclude parameter", {
@@ -382,12 +385,12 @@ test_that("summarize_transcript_files handles names_to_exclude parameter", {
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
   # Test without exclusions
   result1 <- summarize_transcript_files(
     transcript_file_names = transcript_file_names,
-    data_folder = ".",
+    data_folder = test_root,
     transcripts_folder = "test_transcripts"
   )
   expect_equal(nrow(result1), 6) # 2 files * 3 speakers each
@@ -395,13 +398,13 @@ test_that("summarize_transcript_files handles names_to_exclude parameter", {
   # Test with exclusions
   result2 <- summarize_transcript_files(
     transcript_file_names = transcript_file_names,
-    data_folder = ".",
+    data_folder = test_root,
     transcripts_folder = "test_transcripts",
     names_to_exclude = c("Alice", "Bob")
   )
   expect_equal(nrow(result2), 2) # 2 files * 1 speaker each (Charlie only)
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })
 
 test_that("summarize_transcript_files handles metadata preservation with row_id", {
@@ -452,11 +455,11 @@ test_that("summarize_transcript_files handles metadata preservation with row_id"
   on.exit(assignInNamespace("summarize_transcript_metrics", orig, ns = "engager"))
 
   # Create a fake transcripts folder
-  dir.create("test_transcripts", showWarnings = FALSE)
+  dir.create(test_transcripts_dir, showWarnings = FALSE)
 
   result <- summarize_transcript_files(
     transcript_file_names = transcript_file_names,
-    data_folder = ".",
+    data_folder = test_root,
     transcripts_folder = "test_transcripts"
   )
 
@@ -468,5 +471,5 @@ test_that("summarize_transcript_files handles metadata preservation with row_id"
   expect_true("Bob" %in% result$name)
   expect_true("Charlie" %in% result$name)
 
-  unlink("test_transcripts", recursive = TRUE)
+  unlink(test_transcripts_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-write_metrics-comprehensive.R
+++ b/tests/testthat/test-write_metrics-comprehensive.R
@@ -279,26 +279,19 @@ test_that("write_metrics creates parent directories", {
   expect_true(dir.exists(dirname(tmp_file)))
 })
 
-test_that("write_metrics uses default filename when path is NULL", {
+test_that("write_metrics requires an explicit path without writing", {
   test_data <- tibble::tibble(
     name = "Student1",
     comment_count = 5
   )
 
-  # Change to temp directory to avoid cluttering current directory
-  old_wd <- getwd()
-  tmp_dir <- tempdir()
-  setwd(tmp_dir)
-  on.exit(
-    {
-      setwd(old_wd)
-      unlink("engagement_metrics.csv")
-    },
-    add = TRUE
+  work_dir <- withr::local_tempdir()
+  withr::local_dir(work_dir)
+  expect_error(
+    write_metrics(test_data, what = "engagement"),
+    "explicit non-empty file path"
   )
-
-  result <- write_metrics(test_data, what = "engagement")
-  expect_true(file.exists("engagement_metrics.csv"))
+  expect_length(list.files(work_dir, all.files = TRUE, no.. = TRUE), 0)
 })
 
 test_that("write_metrics handles empty tibble", {

--- a/tests/testthat/test-write_section_names_lookup.R
+++ b/tests/testthat/test-write_section_names_lookup.R
@@ -1,5 +1,5 @@
 test_that("write_section_names_lookup writes a CSV and returns a tibble", {
-  temp_dir <- tempdir()
+  temp_dir <- withr::local_tempdir()
   temp_file <- "test_section_names_lookup.csv"
   df <- tibble::tibble(
     course_section = c("101.A", "201.B"),
@@ -17,11 +17,10 @@ test_that("write_section_names_lookup writes a CSV and returns a tibble", {
   written <- readr::read_csv(file.path(temp_dir, temp_file), show_col_types = FALSE)
   expect_equal(nrow(written), 2)
   expect_equal(written$preferred_name, c("Alice", "Bob"))
-  unlink(file.path(temp_dir, temp_file))
 })
 
 test_that("write_section_names_lookup handles empty input", {
-  temp_dir <- tempdir()
+  temp_dir <- withr::local_tempdir()
   temp_file <- "test_section_names_lookup_empty.csv"
   df <- tibble::tibble(
     course_section = character(),
@@ -38,9 +37,60 @@ test_that("write_section_names_lookup handles empty input", {
   expect_true(file.exists(file.path(temp_dir, temp_file)))
   written <- readr::read_csv(file.path(temp_dir, temp_file), show_col_types = FALSE)
   expect_equal(nrow(written), 0)
-  unlink(file.path(temp_dir, temp_file))
 })
 
 test_that("write_section_names_lookup handles invalid input gracefully", {
-  expect_silent(write_section_names_lookup(NULL, data_folder = tempdir(), section_names_lookup_file = "should_not_exist.csv"))
+  temp_dir <- withr::local_tempdir()
+  expect_null(
+    write_section_names_lookup(
+      NULL,
+      data_folder = temp_dir,
+      section_names_lookup_file = "should_not_exist.csv"
+    )
+  )
+  expect_false(file.exists(file.path(temp_dir, "should_not_exist.csv")))
+})
+
+test_that("write_section_names_lookup requires explicit valid destinations", {
+  temp_dir <- withr::local_tempdir()
+  df <- tibble::tibble(
+    course_section = "101.A",
+    day = "Mon",
+    time = "09:00",
+    course = 101L,
+    section = "A",
+    preferred_name = "Alice",
+    formal_name = "Alice Smith",
+    transcript_name = "Alice",
+    student_id = 1
+  )
+  nonexistent <- file.path(temp_dir, "not-created")
+  ordinary_file <- file.path(temp_dir, "ordinary-file")
+  file.create(ordinary_file)
+  before <- list.files(temp_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE)
+
+  for (data_folder in list(NULL, "", NA_character_, character(), nonexistent, ordinary_file)) {
+    expect_error(
+      write_section_names_lookup(df, data_folder = data_folder),
+      "data_folder"
+    )
+  }
+  for (lookup_file in list(
+    "", NA_character_, character(), c("one", "two"), 1,
+    ".", "..", "nested/output.csv", "nested\\output.csv"
+  )) {
+    expect_error(
+      write_section_names_lookup(
+        df,
+        data_folder = temp_dir,
+        section_names_lookup_file = lookup_file
+      ),
+      "section_names_lookup_file"
+    )
+  }
+
+  expect_identical(
+    list.files(temp_dir, all.files = TRUE, no.. = TRUE, recursive = TRUE),
+    before
+  )
 })

--- a/tests/testthat/test.csv
+++ b/tests/testthat/test.csv
@@ -1,4 +1,0 @@
-recording_id,topic,start_time,dept,course,section,course_section,session_date,session_time,instructor,notes
-123456789,CS 101 Lecture 1,"Jan 15, 2024 10:00 AM",CS,101,01,CS.101.01,2024-01-15,10:00,Dr. Smith,NA
-987654321,MATH 250 Discussion,"Jan 16, 2024 09:00 AM",MATH,250,01,MATH.250.01,2024-01-16,09:00,Dr. Johnson,NA
-456789123,LTF 201 Lab,"Jan 17, 2024 02:00 PM",LTF,201,01,LTF.201.01,2024-01-17,14:00,Dr. Brown,NA


### PR DESCRIPTION
## Summary

- semantically forward-port the accepted 0.1.0 CRAN documentation, example, and explicit-write remediation to 0.1.1 after #590
- preserve the public 0.1.1 attendance/report implementation and exact 37-export allowlist
- reject malformed or missing write destinations before filesystem side effects, including compatibility helpers
- mark the previous 0.1.1 candidate checksum as historical and superseded; hosted checks, fresh-user QA, checksum approval, and release GO remain pending

This is the bounded forward-port tracked by #576. It does not close #4 or #576.

## CRAN reviewer request preserved

Konstanze Lauseker requested:

> Please add \value to .Rd files regarding exported methods and explain the functions results in the documentation. Please write about the structure of the output (class) and also what the output means.

> You have examples for unexported functions. Please either omit these examples or export these functions.

> Some code lines in examples are commented out. Please never do that. Ideally find toy examples that can be regularly executed and checked.

> Please unwrap the examples if they are executable in < 5 sec, or replace dontrun{} with donttest{}.

> Please ensure that your functions do not write by default or in your examples/vignettes/tests in the user's home filespace (including the package directory and getwd()). This is not allowed by CRAN policies. Please omit any default path in writing functions. In your examples/vignettes/tests you can write to tempdir().

## Boundary

- version remains `0.1.1`
- `DESCRIPTION` and `NAMESPACE` are unchanged
- exactly 37 functions remain exported
- `analyze_multi_session_attendance()` and `generate_attendance_report()` remain public and unchanged
- no feature, dependency, export, schema, transcript format, privacy claim, or release mutation is added
- `main`, PR #584, PR #586, issue #4, tags, releases, and CRAN state are untouched

## Validation

- `devtools::document()` with roxygen2 7.3.3
- documentation-contract and explicit-write regression tests: pass
- all 70 example files, including `\donttest{}`: pass
- full tests: 0 failures; 68 expected warning-path assertions; 5 documented skips
- canonical `Rscript scripts/pre-pr-validation.R`: pass
- local `R CMD check --as-cran`: 0 errors, 0 warnings, 1 environment note (`unable to verify current time`)
- disposable source tarball: 289 entries; 0 prohibited project/local/generated/nested-archive artifacts
- installed-package UAT: PASS, including the exact export allowlist, attendance/reporting, privacy screens, and explicit writes

## Remaining gates

- exact-head hosted `R-CMD-check`, Coverage, Linux, Windows, and macOS checks
- review findings and thread resolution
- separate maintainer authorization before merge
- post-merge QA artifact and fresh-user QA

No release candidate, checksum approval, upload, tag, release, or GO disposition is created by this PR.
